### PR TITLE
打包后静态资源地址定位在根目录中，无法放到二级目录或更深层级

### DIFF
--- a/.roadhogrc
+++ b/.roadhogrc
@@ -6,6 +6,7 @@
     "transform-class-properties",
     ["import", { "libraryName": "antd", "libraryDirectory": "es", "style": true }]
   ],
+  "publicPath": "./",
   "env": {
     "development": {
       "extraBabelPlugins": [


### PR DESCRIPTION
将dist文件实际部署到网站中，只要不是根目录就会报错，js文件访问地址错误