### PR TITLE
fix(GlobalFooter): manually define link item keys

### DIFF
--- a/src/components/GlobalFooter/demo/basic.md
+++ b/src/components/GlobalFooter/demo/basic.md
@@ -11,12 +11,16 @@ import GlobalFooter from 'ant-design-pro/lib/GlobalFooter';
 import { Icon } from 'antd';
 
 const links = [{
+  key: '帮助',
   title: '帮助',
   href: '',
 }, {
-  title: '隐私',
-  href: '',
+  key: 'github'
+  title: <Icon type="github" />,
+  href: 'https://github.com/ant-design/ant-design-pro',
+  blankTarget: true,
 }, {
+  key: '条款',
   title: '条款',
   href: '',
   blankTarget: true,

--- a/src/components/GlobalFooter/index.js
+++ b/src/components/GlobalFooter/index.js
@@ -11,7 +11,7 @@ export default ({ className, links, copyright }) => {
           <div className={styles.links}>
             {links.map(link => (
               <a
-                key={link.title}
+                key={link.key}
                 target={link.blankTarget ? '_blank' : '_self'}
                 href={link.href}
               >

--- a/src/layouts/BasicLayout.js
+++ b/src/layouts/BasicLayout.js
@@ -184,14 +184,17 @@ class BasicLayout extends React.PureComponent {
             </div>
             <GlobalFooter
               links={[{
+                key: 'Pro 首页',
                 title: 'Pro 首页',
                 href: 'http://pro.ant.design',
                 blankTarget: true,
               }, {
-                title: 'GitHub',
+                key: 'github',
+                title: <Icon type="github" />,
                 href: 'https://github.com/ant-design/ant-design-pro',
                 blankTarget: true,
               }, {
+                key: 'Ant Design',
                 title: 'Ant Design',
                 href: 'http://ant.design',
                 blankTarget: true,

--- a/src/layouts/UserLayout.js
+++ b/src/layouts/UserLayout.js
@@ -11,9 +11,11 @@ const links = [{
   title: '帮助',
   href: '',
 }, {
+  key: '隐私',
   title: '隐私',
   href: '',
 }, {
+  key: '隐私',
   title: '条款',
   href: '',
 }];


### PR DESCRIPTION
at the moment `title` is incompatible as a key field when using `ReactNode` as the documentation suggests since it translates to `[object Object]`.

this pr holds users responsible for defining unique keys in their `items` prop arrays.

i neglected writing a fallback to using `title` as a key if it is an instance of String, would not mind implementing this for the sake of backwards compatibility. 

any input is appreciated, working with ant is truly a pleasure 