### PR TITLE
BasicLayout Slider breakpoint: md => lg

### DIFF
--- a/src/components/SiderMenu/SiderMenu.js
+++ b/src/components/SiderMenu/SiderMenu.js
@@ -213,7 +213,7 @@ export default class SiderMenu extends PureComponent {
         trigger={null}
         collapsible
         collapsed={collapsed}
-        breakpoint="md"
+        breakpoint="lg"
         onCollapse={onCollapse}
         width={256}
         className={styles.sider}


### PR DESCRIPTION
`BasicLayout` 布局 `SliderMenu` `breakpoint` 目前是失效的，是因为 `isMobile` 的检测
因此，修改为`md => lg` 能够正常触发布局断点，从而能够正常响应布局