### PR TITLE
修复面包屑显示不正确的问题

### DIFF
--- a/src/components/PageHeader/index.js
+++ b/src/components/PageHeader/index.js
@@ -9,13 +9,15 @@ import styles from './index.less';
 const { TabPane } = Tabs;
 
 function getBreadcrumb(breadcrumbNameMap, url) {
-  let breadcrumb = {};
-  Object.keys(breadcrumbNameMap).forEach((item) => {
-    if (pathToRegexp(item).test(url)) {
-      breadcrumb = breadcrumbNameMap[item];
-    }
-  });
-  return breadcrumb;
+  let breadcrumb = breadcrumbNameMap[url];
+  if (!breadcrumb) {
+    Object.keys(breadcrumbNameMap).forEach((item) => {
+      if (pathToRegexp(item).test(url)) {
+        breadcrumb = breadcrumbNameMap[item];
+      }
+    });
+  }
+  return breadcrumb || {};
 }
 
 export default class PageHeader extends PureComponent {


### PR DESCRIPTION
 面包屑在某些情况下显示不正确，例如：
新建issue：`/issues/new` ，会被认为 issue详情：`/issues/:id`