### PR TITLE
Add longer default timeout and pass done() for jasmine async

### DIFF
--- a/src/e2e/home.e2e.js
+++ b/src/e2e/home.e2e.js
@@ -1,9 +1,11 @@
 import Nightmare from 'nightmare';
 
 describe('Homepage', () => {
-  it('it should have logo text', async () => {
+  jasmine.DEFAULT_TIMEOUT_INTERVAL = 300000; // 5 minute timeout
+  it('it should have logo text', async (done) => {
     const page = Nightmare().goto('http://localhost:8000');
     const text = await page.wait('h1').evaluate(() => document.body.innerHTML).end();
     expect(text).toContain('<h1>Ant Design Pro</h1>');
+    done();
   });
 });

--- a/src/e2e/login.e2e.js
+++ b/src/e2e/login.e2e.js
@@ -1,6 +1,7 @@
 import Nightmare from 'nightmare';
 
 describe('Login', () => {
+  jasmine.DEFAULT_TIMEOUT_INTERVAL = 300000; // 5 minute timeout
   let page;
   beforeEach(() => {
     page = Nightmare();
@@ -12,15 +13,16 @@ describe('Login', () => {
       .goto('http://localhost:8000/#/user/login');
   });
 
-  it('should login with failure', async () => {
+  it('should login with failure', async (done) => {
     await page.type('#userName', 'mockuser')
       .type('#password', 'wrong_password')
       .click('button[type="submit"]')
       .wait('.ant-alert-error') // should display error
       .end();
+    done();
   });
 
-  it('should login successfully', async () => {
+  it('should login successfully', async (done) => {
     const text = await page.type('#userName', 'admin')
       .type('#password', '888888')
       .click('button[type="submit"]')
@@ -28,5 +30,6 @@ describe('Login', () => {
       .evaluate(() => document.body.innerHTML)
       .end();
     expect(text).toContain('<h1>Ant Design Pro</h1>');
+    done();
   });
 });


### PR DESCRIPTION
Sort've fixes #776 

There could be a better way to implement a higher default timeout but I'm unsure.
I will modify if you know of a better way.