### PR TITLE
Default guest and fix authority's undefined sometimes

### DIFF
--- a/src/utils/authority.js
+++ b/src/utils/authority.js
@@ -1,8 +1,8 @@
 // use localStorage to store the authority info, which might be sent from server in actual project.
 export function getAuthority() {
-  return localStorage.getItem('antd-pro-authority') || 'admin';
+  return localStorage.getItem('antd-pro-authority') || 'guest';
 }
 
-export function setAuthority(authority) {
+export function setAuthority(authority = 'guest') {
   return localStorage.setItem('antd-pro-authority', authority);
 }


### PR DESCRIPTION
No default of authority in local storage will cause the problem that `/` -> `/user/login` , `/user/login` -> `/` loop always.