### PR TITLE
 breadcrumb separator custom

### DIFF
--- a/src/components/PageHeader/index.js
+++ b/src/components/PageHeader/index.js
@@ -43,10 +43,13 @@ export default class PageHeader extends PureComponent {
   // Generated according to props
   conversionFromProps= () => {
     const {
-      breadcrumbList, linkElement = 'a',
+      breadcrumbList, breadcrumbSeparator, linkElement = 'a',
     } = this.props;
     return (
-      <Breadcrumb className={styles.breadcrumb}>
+      <Breadcrumb
+        className={styles.breadcrumb}
+        separator={breadcrumbSeparator}
+      >
         {breadcrumbList.map(item => (
           <Breadcrumb.Item key={item.title}>
             {item.href ? (createElement(linkElement, {
@@ -58,7 +61,7 @@ export default class PageHeader extends PureComponent {
     );
   }
   conversionFromLocation = (routerLocation, breadcrumbNameMap) => {
-    const { linkElement = 'a' } = this.props;
+    const { breadcrumbSeparator, linkElement = 'a' } = this.props;
     // Convert the path to an array
     const pathSnippets = routerLocation.pathname.split('/').filter(i => i);
     // Loop data mosaic routing
@@ -84,7 +87,10 @@ export default class PageHeader extends PureComponent {
       </Breadcrumb.Item>
     );
     return (
-      <Breadcrumb className={styles.breadcrumb}>
+      <Breadcrumb
+        className={styles.breadcrumb}
+        separator={breadcrumbSeparator}
+      >
         {extraBreadcrumbItems}
       </Breadcrumb>
     );
@@ -94,7 +100,7 @@ export default class PageHeader extends PureComponent {
    * Convert parameters into breadcrumbs
    */
   conversionBreadcrumbList = () => {
-    const { breadcrumbList } = this.props;
+    const { breadcrumbList, breadcrumbSeparator } = this.props;
     const { routes, params, routerLocation, breadcrumbNameMap } = this.getBreadcrumbProps();
     if (breadcrumbList && breadcrumbList.length) {
       return this.conversionFromProps();
@@ -108,6 +114,7 @@ export default class PageHeader extends PureComponent {
           routes={routes.filter(route => route.breadcrumbName)}
           params={params}
           itemRender={this.itemRender}
+          separator={breadcrumbSeparator}
         />
       );
     }

--- a/src/components/SiderMenu/SiderMenu.js
+++ b/src/components/SiderMenu/SiderMenu.js
@@ -213,7 +213,7 @@ export default class SiderMenu extends PureComponent {
         trigger={null}
         collapsible
         collapsed={collapsed}
-        breakpoint="md"
+        breakpoint="lg"
         onCollapse={onCollapse}
         width={256}
         className={styles.sider}


### PR DESCRIPTION
### 增加组件 `PageHeader` 接受自定义面包屑分隔符的功能

> 可定义`separator`属性，支持 `string` 和 `element`，可参照 `Ant Design` 面包屑中的 `separator`，功能和参数完全一致

- 直接在 `layouts/PageHeaderLayout` 文件中添加公共分隔符
- 使用 `PageHeaderLayout` 布局独立自定义分隔符

#### 代码示例
- 在 `components/PageHeader/index.js` 中添加公共分隔符
```
<PageHeader key="pageheader" {...restProps} linkElement={Link} breadcrumbSeparator={<Icon type="swap-right" />} />
```

- 使用 `PageHeaderLayout` 布局组件
```
import PageHeaderLayout from '../../layouts/PageHeaderLayout';

<PageHeaderLayout breadcrumbSeparator={<Icon type="swap-right" />}>
    // code...
</PageHeaderLayout>
```

注意：在 `PageHeader` 或 `PageHeaderLayout` 使用 `breadcrumbSeparator` 来自定义分隔符