### PR TITLE
fix Authorized Promise render recreating

### DIFF
--- a/src/components/Authorized/PromiseRender.js
+++ b/src/components/Authorized/PromiseRender.js
@@ -5,10 +5,20 @@ export default class PromiseRender extends React.PureComponent {
   state = {
     component: null,
   };
+
   componentDidMount() {
-    const ok = this.checkIsInstantiation(this.props.ok);
-    const error = this.checkIsInstantiation(this.props.error);
-    this.props.promise
+    this.setRenderComponent(this.props);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    // new Props enter
+    this.setRenderComponent(nextProps);
+  }
+  // set render Component : ok or error
+  setRenderComponent(props) {
+    const ok = this.checkIsInstantiation(props.ok);
+    const error = this.checkIsInstantiation(props.error);
+    props.promise
       .then(() => {
         this.setState({
           component: ok,

--- a/src/components/Authorized/PromiseRender.js
+++ b/src/components/Authorized/PromiseRender.js
@@ -5,11 +5,9 @@ export default class PromiseRender extends React.PureComponent {
   state = {
     component: null,
   };
-
   componentDidMount() {
     this.setRenderComponent(this.props);
   }
-
   componentWillReceiveProps(nextProps) {
     // new Props enter
     this.setRenderComponent(nextProps);


### PR DESCRIPTION
when PromiseRender receivers new props ,the method componentDidMount will not execute ,so 'this.state.component' will not change ,ant it will cause when you change the page ,the component will not change ,so you will get the warning says that 'the Hash history cannot PUSH the same path; a new entry will not be added to the history stack '. and the page will not load correct

![image](https://user-images.githubusercontent.com/15883471/36726592-49ce5ccc-1bf5-11e8-9960-22c4dc4e74bd.png)
