### PR TITLE
Improve the display of bread crumbs

### DIFF
--- a/src/layouts/BasicLayout.js
+++ b/src/layouts/BasicLayout.js
@@ -38,6 +38,25 @@ const getRedirect = (item) => {
 };
 getMenuData().forEach(getRedirect);
 
+/**
+ * 获取面包屑映射
+ * @param {Object} menuData 菜单配置
+ * @param {Object} routerData 路由配置
+ */
+const getBreadcrumbNameMap = (menuData, routerData) => {
+  const result = {};
+  const childResult = {};
+  for (const i of menuData) {
+    if (!routerData[`${i.path}`]) {
+      result[`${i.path}`] = i;
+    }
+    if (i.children) {
+      Object.assign(childResult, getBreadcrumbNameMap(i.children, routerData));
+    }
+  }
+  return Object.assign({}, routerData, result, childResult);
+};
+
 const query = {
   'screen-xs': {
     maxWidth: 575,
@@ -76,7 +95,7 @@ class BasicLayout extends React.PureComponent {
     const { location, routerData } = this.props;
     return {
       location,
-      breadcrumbNameMap: routerData,
+      breadcrumbNameMap: getBreadcrumbNameMap(getMenuData(), routerData),
     };
   }
   componentDidMount() {

--- a/src/layouts/BasicLayout.js
+++ b/src/layouts/BasicLayout.js
@@ -47,8 +47,8 @@ const getBreadcrumbNameMap = (menuData, routerData) => {
   const result = {};
   const childResult = {};
   for (const i of menuData) {
-    if (!routerData[`${i.path}`]) {
-      result[`${i.path}`] = i;
+    if (!routerData[i.path]) {
+      result[i.path] = i;
     }
     if (i.children) {
       Object.assign(childResult, getBreadcrumbNameMap(i.children, routerData));


### PR DESCRIPTION
现在的面包屑是这样显示的：
![image](https://user-images.githubusercontent.com/22371089/37141046-c3d91aca-22ee-11e8-95eb-19838f2d3d94.png)
这个 PR 会将面包屑优化成这个样子：
![1edc417f18c040210a8d469f32a8775](https://user-images.githubusercontent.com/22371089/37141070-de18937a-22ee-11e8-83eb-7b8e662e985a.png)
完善了面包屑的层级展示。

---

思路是传到 `context` 的 `breadcrumbNameMap` 参数除了包含 `routerData` 里定义的内容外，还添加了 `menuData` 中定义的一些没有在 `routerData` 中定义的父级对象。