### PR TITLE
fix redirect loop

### DIFF
--- a/src/layouts/BasicLayout.js
+++ b/src/layouts/BasicLayout.js
@@ -17,7 +17,7 @@ import { getMenuData } from '../common/menu';
 import logo from '../assets/logo.svg';
 
 const { Content, Header, Footer } = Layout;
-const { AuthorizedRoute } = Authorized;
+const { AuthorizedRoute, check } = Authorized;
 
 /**
  * 根据菜单取得重定向地址.
@@ -109,7 +109,11 @@ class BasicLayout extends React.PureComponent {
       urlParams.searchParams.delete('redirect');
       window.history.replaceState(null, 'redirect', urlParams.href);
     } else {
-      return '/dashboard/analysis';
+      const { routerData } = this.props;
+      // get the first authorized route path in routerData
+      const authorizedPath = Object.keys(routerData).find(item =>
+        check(routerData[item].authority, item, undefined) && item !== '/');
+      return authorizedPath;
     }
     return redirect;
   }

--- a/src/layouts/BasicLayout.js
+++ b/src/layouts/BasicLayout.js
@@ -112,7 +112,7 @@ class BasicLayout extends React.PureComponent {
       const { routerData } = this.props;
       // get the first authorized route path in routerData
       const authorizedPath = Object.keys(routerData).find(item =>
-        check(routerData[item].authority, item, undefined) && item !== '/');
+        check(routerData[item].authority, item) && item !== '/');
       return authorizedPath;
     }
     return redirect;


### PR DESCRIPTION
#1098 

访问 '/' 时定向到已授权的第一个页面，而非写死的 'dashboard/analysis'，避免无权限时登录后就定向到 403（或点击 logo 定向到403）