### PR TITLE
:bug: fix inner exact cover custom exact bug

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -141,10 +141,10 @@ export function getRoutes(path, routerData) {
   const renderRoutes = renderArr.map((item) => {
     const exact = !routes.some(route => route !== item && getRelation(route, item) === 1);
     return {
+      exact,
       ...routerData[`${path}${item}`],
       key: `${path}${item}`,
       path: `${path}${item}`,
-      exact,
     };
   });
   return renderRoutes;


### PR DESCRIPTION
In `src/utils/utils.js`
```js
  const renderRoutes = renderArr.map((item) => {
    const exact = !routes.some(route => route !== item && getRelation(route, item) === 1);
    return {
      ...routerData[`${path}${item}`],
      key: `${path}${item}`,
      path: `${path}${item}`,
      exact,
    };
  });
```

if i want to reset or custmize exact in `common/router`, it is impossible, because inner exact will cover what i set, so hoist it.

---

and i have a question

if i have two router component named `/room/supervision` and `/room/supervision/:id`

in `utils/utils`  [click here](https://github.com/ant-design/ant-design-pro/blob/master/src/utils/utils.js#L138-L139)

will remove the deep rendering component `/room/supervision/:id`

i want to remove `const renderArr = getRenderArr(routes);`

It looks the same.
