### PR TITLE
Fix TimelineChart time format issue

### DIFF
--- a/src/components/Charts/TimelineChart/index.js
+++ b/src/components/Charts/TimelineChart/index.js
@@ -71,8 +71,8 @@ export default class TimelineChart extends React.Component {
 
     const timeScale = {
       type: 'time',
-      tickCount: 10,
-      mask: 'HH:MM',
+      tickInterval: 60 * 60 * 1000,
+      mask: 'HH:mm',
       range: [0, 1],
     };
 


### PR DESCRIPTION
- Use `tickInterval` instead of `tickCount` to  avoid timeline mismatching.
- Change `mask` from `HH:MM` to `HH:mm`, since `MM` means month while `mm` means minutes. (https://momentjs.com/docs/#/displaying/)

Before (https://preview.pro.ant.design/#/dashboard/analysis):

![image](https://user-images.githubusercontent.com/4597409/38667944-7468a120-3e75-11e8-81b6-e357703b46d9.png)

After

![image](https://user-images.githubusercontent.com/4597409/38667952-79b0b5a0-3e75-11e8-84be-5c6e24b1668d.png)

