### PR TITLE
fix: babel transform failed with transform-decorators-legacy

### DIFF
--- a/.webpackrc.js
+++ b/.webpackrc.js
@@ -3,7 +3,6 @@ const path = require('path');
 export default {
   entry: 'src/index.js',
   extraBabelPlugins: [
-    'transform-decorators-legacy',
     ['import', { libraryName: 'antd', libraryDirectory: 'es', style: true }],
   ],
   env: {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "babel-plugin-dva-hmr": "^0.4.1",
     "babel-plugin-import": "^1.6.7",
     "babel-plugin-module-resolver": "^3.1.1",
-    "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "cross-env": "^5.1.1",
     "cross-port-killer": "^1.0.1",
     "enzyme": "^3.1.0",


### PR DESCRIPTION
Close #1347
Close #1346

由于 [babel@7 升级](https://github.com/babel/babel/pull/7734)导致的 break change，`transform-decorators-legacy` 无需引入了。

不删会有这个报错。

```
Property right of AssignmentExpression expected node to be of a type ["Expression"] but instead got null
```