### PR TITLE
Fix functionName typo from getMeunMatcheys to getMeunMatchKeys

### DIFF
--- a/src/components/SiderMenu/SiderMenu.js
+++ b/src/components/SiderMenu/SiderMenu.js
@@ -22,7 +22,7 @@ const getIcon = icon => {
   return icon;
 };
 
-export const getMeunMatcheys = (flatMenuKeys, path) => {
+export const getMeunMatchKeys = (flatMenuKeys, path) => {
   return flatMenuKeys.filter(item => {
     return pathToRegexp(item).test(path);
   });
@@ -53,7 +53,7 @@ export default class SiderMenu extends PureComponent {
     const { location: { pathname } } = props || this.props;
     return urlToList(pathname)
       .map(item => {
-        return getMeunMatcheys(this.flatMenuKeys, item)[0];
+        return getMeunMatchKeys(this.flatMenuKeys, item)[0];
       })
       .filter(item => item);
   }
@@ -159,7 +159,7 @@ export default class SiderMenu extends PureComponent {
   // Get the currently selected menu
   getSelectedMenuKeys = () => {
     const { location: { pathname } } = this.props;
-    return urlToList(pathname).map(itemPath => getMeunMatcheys(this.flatMenuKeys, itemPath).pop());
+    return urlToList(pathname).map(itemPath => getMeunMatchKeys(this.flatMenuKeys, itemPath).pop());
   };
   // conversion Path
   // 转化路径

--- a/src/components/SiderMenu/SilderMenu.test.js
+++ b/src/components/SiderMenu/SilderMenu.test.js
@@ -1,24 +1,24 @@
-import { getMeunMatcheys } from './SiderMenu';
+import { getMeunMatchKeys } from './SiderMenu';
 
 const meun = ['/dashboard', '/userinfo', '/dashboard/name', '/userinfo/:id', '/userinfo/:id/info'];
 
 describe('test meun match', () => {
   it('simple path', () => {
-    expect(getMeunMatcheys(meun, '/dashboard')).toEqual(['/dashboard']);
+    expect(getMeunMatchKeys(meun, '/dashboard')).toEqual(['/dashboard']);
   });
   it('error path', () => {
-    expect(getMeunMatcheys(meun, '/dashboardname')).toEqual([]);
+    expect(getMeunMatchKeys(meun, '/dashboardname')).toEqual([]);
   });
 
   it('Secondary path', () => {
-    expect(getMeunMatcheys(meun, '/dashboard/name')).toEqual(['/dashboard/name']);
+    expect(getMeunMatchKeys(meun, '/dashboard/name')).toEqual(['/dashboard/name']);
   });
 
   it('Parameter path', () => {
-    expect(getMeunMatcheys(meun, '/userinfo/2144')).toEqual(['/userinfo/:id']);
+    expect(getMeunMatchKeys(meun, '/userinfo/2144')).toEqual(['/userinfo/:id']);
   });
 
   it('three parameter path', () => {
-    expect(getMeunMatcheys(meun, '/userinfo/2144/info')).toEqual(['/userinfo/:id/info']);
+    expect(getMeunMatchKeys(meun, '/userinfo/2144/info')).toEqual(['/userinfo/:id/info']);
   });
 });


### PR DESCRIPTION
The related issue is https://github.com/ant-design/ant-design-pro/issues/1424.