### PR TITLE
fix React.cloneElement in component DescriptionList

### DIFF
--- a/src/components/DescriptionList/DescriptionList.js
+++ b/src/components/DescriptionList/DescriptionList.js
@@ -22,7 +22,7 @@ const DescriptionList = ({
     <div className={clsString} {...restProps}>
       {title ? <div className={styles.title}>{title}</div> : null}
       <Row gutter={gutter}>
-        {React.Children.map(children, child => React.cloneElement(child, { column }))}
+        {React.Children.map(children, child => child ? React.cloneElement(child, { column }) : child)}
       </Row>
     </div>
   );


### PR DESCRIPTION
## Reproduce

React throw a exception when you display `DescriptionList.Description`dynamic  like following codes:

![screenshot from 2018-05-04 05-51-08](https://user-images.githubusercontent.com/4303130/39604543-396e7eb4-4f5f-11e8-99b6-4c67a5cd6b93.png)
![screenshot from 2018-05-04 05-51-28](https://user-images.githubusercontent.com/4303130/39604544-39a509c0-4f5f-11e8-82f5-00556c5194fb.png)

Exception: 

`React.cloneElement(...): The argument must be a React element, but you passed null.`

## Why

Because it clone each children by React top level API `React.cloneElement` in `DescriptionList` for assign `column` attribute.

## How

Just don't clone falsy children in `DescriptionList` (because a `DescriptionList.Description` will never be a falsy value)

``` javascript
React.Children.map(children, child => child ? React.cloneElement(child, { column }) : child)
```