### PR TITLE
Improve getFlatMenuKeys & getMeunMatchKeys for better readability and robustness

### DIFF
--- a/src/components/SiderMenu/SiderMenu.js
+++ b/src/components/SiderMenu/SiderMenu.js
@@ -28,13 +28,14 @@ const getIcon = icon => {
  * @param  menu
  */
 export const getFlatMenuKeys = menu =>
-  menu.reduce((keys, item) => {
-    keys.push(item.path);
-    if (item.children) {
-      return keys.concat(getFlatMenuKeys(item.children));
-    }
-    return keys;
-  }, []);
+  menu
+    .reduce((keys, item) => {
+      keys.push(item.path);
+      if (item.children) {
+        return keys.concat(getFlatMenuKeys(item.children));
+      }
+      return keys;
+    }, []);
 
 /**
  * Find all matched menu keys based on paths
@@ -42,11 +43,11 @@ export const getFlatMenuKeys = menu =>
  * @param  paths: [/abc, /abc/11, /abc/11/info]
  */
 export const getMeunMatchKeys = (flatMenuKeys, paths) =>
-  paths.reduce(
-    (matchKeys, path) =>
-      matchKeys.concat(flatMenuKeys.filter(item => pathToRegexp(item).test(path))),
-    []
-  );
+  paths
+    .reduce((matchKeys, path) => (
+      matchKeys.concat(
+        flatMenuKeys.filter(item => pathToRegexp(item).test(path))
+    )), []);
 
 export default class SiderMenu extends PureComponent {
   constructor(props) {

--- a/src/components/SiderMenu/SilderMenu.test.js
+++ b/src/components/SiderMenu/SilderMenu.test.js
@@ -18,7 +18,7 @@ const menu = [{
 
 const flatMenuKeys = getFlatMenuKeys(menu);
 
-describe('test convert tree structure menu paths to flat menu paths', () => {
+describe('test convert nested menu to flat menu', () => {
   it('simple menu', () => {
     expect(flatMenuKeys).toEqual(
       ['/dashboard', '/dashboard/name', '/userinfo', '/userinfo/:id', '/userinfo/:id/info']

--- a/src/components/SiderMenu/SilderMenu.test.js
+++ b/src/components/SiderMenu/SilderMenu.test.js
@@ -1,24 +1,49 @@
-import { getMeunMatchKeys } from './SiderMenu';
+import { urlToList } from '../_utils/pathTools';
+import { getFlatMenuKeys, getMeunMatchKeys } from './SiderMenu';
 
-const meun = ['/dashboard', '/userinfo', '/dashboard/name', '/userinfo/:id', '/userinfo/:id/info'];
+const menu = [{
+  path: '/dashboard',
+  children: [{
+    path: '/dashboard/name',
+  }],
+}, {
+  path: '/userinfo',
+  children: [{
+    path: '/userinfo/:id',
+    children: [{
+      path: '/userinfo/:id/info',
+    }],
+  }],
+}];
 
-describe('test meun match', () => {
+const flatMenuKeys = getFlatMenuKeys(menu);
+
+describe('test convert tree structure menu paths to flat menu paths', () => {
+  it('simple menu', () => {
+    expect(flatMenuKeys).toEqual(
+      ['/dashboard', '/dashboard/name', '/userinfo', '/userinfo/:id', '/userinfo/:id/info']
+    );
+  })
+});
+
+describe('test menu match', () => {
   it('simple path', () => {
-    expect(getMeunMatchKeys(meun, '/dashboard')).toEqual(['/dashboard']);
+    expect(getMeunMatchKeys(flatMenuKeys, urlToList('/dashboard'), true)).toEqual(['/dashboard']);
   });
+
   it('error path', () => {
-    expect(getMeunMatchKeys(meun, '/dashboardname')).toEqual([]);
+    expect(getMeunMatchKeys(flatMenuKeys, urlToList('/dashboardname'), true)).toEqual([]);
   });
 
   it('Secondary path', () => {
-    expect(getMeunMatchKeys(meun, '/dashboard/name')).toEqual(['/dashboard/name']);
+    expect(getMeunMatchKeys(flatMenuKeys, urlToList('/dashboard/name'), true)).toEqual(['/dashboard', '/dashboard/name']);
   });
 
   it('Parameter path', () => {
-    expect(getMeunMatchKeys(meun, '/userinfo/2144')).toEqual(['/userinfo/:id']);
+    expect(getMeunMatchKeys(flatMenuKeys, urlToList('/userinfo/2144'), true)).toEqual(['/userinfo', '/userinfo/:id']);
   });
 
   it('three parameter path', () => {
-    expect(getMeunMatchKeys(meun, '/userinfo/2144/info')).toEqual(['/userinfo/:id/info']);
+    expect(getMeunMatchKeys(flatMenuKeys, urlToList('/userinfo/2144/info'), false)).toEqual(['/userinfo', '/userinfo/:id', '/userinfo/:id/info']);
   });
 });

--- a/src/components/SiderMenu/SilderMenu.test.js
+++ b/src/components/SiderMenu/SilderMenu.test.js
@@ -28,22 +28,22 @@ describe('test convert tree structure menu paths to flat menu paths', () => {
 
 describe('test menu match', () => {
   it('simple path', () => {
-    expect(getMeunMatchKeys(flatMenuKeys, urlToList('/dashboard'), true)).toEqual(['/dashboard']);
+    expect(getMeunMatchKeys(flatMenuKeys, urlToList('/dashboard'))).toEqual(['/dashboard']);
   });
 
   it('error path', () => {
-    expect(getMeunMatchKeys(flatMenuKeys, urlToList('/dashboardname'), true)).toEqual([]);
+    expect(getMeunMatchKeys(flatMenuKeys, urlToList('/dashboardname'))).toEqual([]);
   });
 
   it('Secondary path', () => {
-    expect(getMeunMatchKeys(flatMenuKeys, urlToList('/dashboard/name'), true)).toEqual(['/dashboard', '/dashboard/name']);
+    expect(getMeunMatchKeys(flatMenuKeys, urlToList('/dashboard/name'))).toEqual(['/dashboard', '/dashboard/name']);
   });
 
   it('Parameter path', () => {
-    expect(getMeunMatchKeys(flatMenuKeys, urlToList('/userinfo/2144'), true)).toEqual(['/userinfo', '/userinfo/:id']);
+    expect(getMeunMatchKeys(flatMenuKeys, urlToList('/userinfo/2144'))).toEqual(['/userinfo', '/userinfo/:id']);
   });
 
   it('three parameter path', () => {
-    expect(getMeunMatchKeys(flatMenuKeys, urlToList('/userinfo/2144/info'), false)).toEqual(['/userinfo', '/userinfo/:id', '/userinfo/:id/info']);
+    expect(getMeunMatchKeys(flatMenuKeys, urlToList('/userinfo/2144/info'))).toEqual(['/userinfo', '/userinfo/:id', '/userinfo/:id/info']);
   });
 });


### PR DESCRIPTION
## getFlatMenuKeys
The purpose of `getFlatMenuKeys` is to form a flat array from a nested array so that using `Array.reduce` might be a better approach to concat formatted value to the final result one by one instead of `Array.forEach`.

Using `Array.reduce` also can ensure the formatted flat array remain the same elements order as the original nested array.

For example, if we have the menu data like below:
```javascript
const menu = [{
  path: '/dashboard',
  children: [{
    path: '/dashboard/name',
  }],
}, {
  path: '/userinfo',
  children: [{
    path: '/userinfo/:id',
    children: [{
      path: '/userinfo/:id/info',
    }],
  }],
}];
```

Before `getFlatMenuKeys` will return
```javascript
[ '/dashboard/name',
  '/dashboard',
  '/userinfo/:id/info',
  '/userinfo/:id',
  '/userinfo' ]
```

By using `Array.reduce` we could get
```javascript
[ '/dashboard',
  '/dashboard/name',
  '/userinfo',
  '/userinfo/:id',
  '/userinfo/:id/info' ]
```

In addition, since `getFlatMenuKeys` has no dependencies on specific Component so that I changed it to a normal function which could be exported easily.

## getMeunMatchKeys
Before `getMeunMatchKeys` is used to filter each possible path with the return of `urlToList`. In order to avoid using `Array.map` every time when we want to call `getMeunMatchKeys`, I passed in the return of `urlToList` as a param so that developer can call `getMeunMatchKeys` like this:

```javascript
getMeunMatchKeys(this.flatMenuKeys, urlToList(pathname));
```
Since we are passing each of possible path to `getMeunMatchKeys`, the filter result from `pathToRegexp` will not be duplicate. We could safely concat them and form the final result. In this way, we could also avoid using `[0]` or `.pop()` to improve code robustness. And by using `Array.reduce`, we don't need to filter `undefined` value for those error path cases whereas `Array.map` will have this problem.

---

I added some tests in `SilderMenu.test.js` as well to make sure this function refactor won't break anything. 🙂 