### PR TITLE
fix broken login page on mobile device with small screen resolution

### DIFF
--- a/src/components/Result/index.less
+++ b/src/components/Result/index.less
@@ -4,6 +4,9 @@
   text-align: center;
   width: 72%;
   margin: 0 auto;
+  @media screen and (max-width: @screen-xs) {
+    width: 100%;
+  }
 
   .icon {
     font-size: 72px;
@@ -39,6 +42,10 @@
     padding: 24px 40px;
     border-radius: @border-radius-sm;
     text-align: left;
+
+    @media screen and (max-width: @screen-xs) {
+      padding: 18px 20px;
+    }
   }
 
   .actions {

--- a/src/routes/Forms/StepForm/Step3.js
+++ b/src/routes/Forms/StepForm/Step3.js
@@ -14,28 +14,34 @@ class Step3 extends React.PureComponent {
     const information = (
       <div className={styles.information}>
         <Row>
-          <Col span={8} className={styles.label}>
+          <Col xs={24} sm={8} className={styles.label}>
             付款账户：
           </Col>
-          <Col span={16}>{data.payAccount}</Col>
+          <Col xs={24} sm={16}>
+            {data.payAccount}
+          </Col>
         </Row>
         <Row>
-          <Col span={8} className={styles.label}>
+          <Col xs={24} sm={8} className={styles.label}>
             收款账户：
           </Col>
-          <Col span={16}>{data.receiverAccount}</Col>
+          <Col xs={24} sm={16}>
+            {data.receiverAccount}
+          </Col>
         </Row>
         <Row>
-          <Col span={8} className={styles.label}>
+          <Col xs={24} sm={8} className={styles.label}>
             收款人姓名：
           </Col>
-          <Col span={16}>{data.receiverName}</Col>
+          <Col xs={24} sm={16}>
+            {data.receiverName}
+          </Col>
         </Row>
         <Row>
-          <Col span={8} className={styles.label}>
+          <Col xs={24} sm={8} className={styles.label}>
             转账金额：
           </Col>
-          <Col span={16}>
+          <Col xs={24} sm={16}>
             <span className={styles.money}>{data.amount}</span> 元
           </Col>
         </Row>

--- a/src/routes/Forms/StepForm/style.less
+++ b/src/routes/Forms/StepForm/style.less
@@ -60,6 +60,9 @@
     color: @heading-color;
     text-align: right;
     padding-right: 8px;
+    @media screen and (max-width: @screen-sm) {
+      text-align: left;
+    }
   }
 }
 

--- a/src/routes/User/Login.less
+++ b/src/routes/User/Login.less
@@ -3,6 +3,9 @@
 .main {
   width: 368px;
   margin: 0 auto;
+  @media screen and (max-width: @screen-sm) {
+    width: 95%;
+  }
 
   .icon {
     font-size: 24px;


### PR DESCRIPTION
## Screenshot

![_20180513174802](https://user-images.githubusercontent.com/4303130/39965977-4d40306c-56d6-11e8-8470-9558df58dddf.jpg)

## Reproduce

Open login page of this project. Then click `Toggle device toolbar` in Chrome devTools and select `iPhone 5/SE` in toolbar

## Why

The width of main container in login page be locked(fixed) in `src/routes/User/Login.less` 

## How

Set width to 95%(5% for gap) in small screen resolution device.

``` css
  @media screen and (max-width: @screen-sm) {
    width: 95%;
  }
```