### PR TITLE
fix: layout overflow style with fixSiderbar

### DIFF
--- a/src/layouts/BasicLayout.js
+++ b/src/layouts/BasicLayout.js
@@ -88,7 +88,6 @@ class BasicLayout extends React.PureComponent {
     if (fixSiderbar) {
       return {
         height: '100vh',
-        overflow: 'auto',
       };
     }
     return null;

--- a/src/routes/Account/Settings/Info.js
+++ b/src/routes/Account/Settings/Info.js
@@ -19,15 +19,6 @@ const menuMap = {
   currentUser: user.currentUser,
 }))
 export default class Info extends Component {
-  static getDerivedStateFromProps(props, state) {
-    const { match, location } = props;
-    let selectKey = location.pathname.replace(`${match.path}/`, '');
-    selectKey = menuMap[selectKey] ? selectKey : 'base';
-    if (selectKey !== state.selectKey) {
-      return { selectKey };
-    }
-    return null;
-  }
   constructor(props) {
     super(props);
     const { match, location } = props;
@@ -37,6 +28,15 @@ export default class Info extends Component {
       selectKey: key,
       mode: 'inline',
     };
+  }
+  static getDerivedStateFromProps(props, state) {
+    const { match, location } = props;
+    let selectKey = location.pathname.replace(`${match.path}/`, '');
+    selectKey = menuMap[selectKey] ? selectKey : 'base';
+    if (selectKey !== state.selectKey) {
+      return { selectKey };
+    }
+    return null;
   }
   componentDidMount() {
     window.addEventListener('resize', this.resize);


### PR DESCRIPTION
这里没有必要加 `overflow: 'auto'` 这个样式，加了反而会导致原本的 `overflow-x: hidden` 被覆盖掉，使得部分页面（监控页）在某些情况下（宽度较大）出现横向滚动条