### PR TITLE
fix: add property className into interface IHeaderSearchProps

### DIFF
--- a/src/components/HeaderSearch/index.d.ts
+++ b/src/components/HeaderSearch/index.d.ts
@@ -6,6 +6,7 @@ export interface IHeaderSearchProps {
   onChange?: (value: string) => void;
   onPressEnter?: (value: string) => void;
   style?: React.CSSProperties;
+  className?: string;
 }
 
 export default class HeaderSearch extends React.Component<IHeaderSearchProps, any> {}


### PR DESCRIPTION
在TS中，引入HeaderSearch组件会提示
```
[ts] Property 'className' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<HeaderSearch> & Readonly<{ children?: ReactNode; }...'.
```
发现在 `ant-design-pro/es/HeaderSearch/index.d.ts` 中IHeaderSearchProps接口中缺少对className的定义。