### PR TITLE
fix: layout height

### DIFF
--- a/src/components/SiderMenu/index.less
+++ b/src/components/SiderMenu/index.less
@@ -25,7 +25,7 @@
 }
 
 .sider {
-  min-height: 100vh;
+  min-height: 100%;
   box-shadow: 2px 0 6px rgba(0, 21, 41, 0.35);
   position: relative;
   z-index: 10;

--- a/src/index.less
+++ b/src/index.less
@@ -10,7 +10,7 @@ body,
 }
 
 :global(.ant-layout) {
-  min-height: 100%;
+  min-height: 100vh;
 }
 
 canvas {


### PR DESCRIPTION
修复了 Siderbar 固定时部分页面高度的问题，其实本来都用 `100%` 就可以的，但是 `.root` 这个元素的子元素是一个 `.screen-xx` 这样的一个元素，这个元素没有设置高度，所以 `.ant-layout` 得用 `100vh` 了