### PR TITLE
feature: add <Authorized/> authority function After performing return Promise is render <PromiseRender/> component

### DIFF
--- a/src/components/Authorized/CheckPermissions.js
+++ b/src/components/Authorized/CheckPermissions.js
@@ -49,11 +49,11 @@ const checkPermissions = (authority, currentAuthority, target, Exception) => {
   if (typeof authority === 'function') {
     try {
       const bool = authority(currentAuthority);
+      // 函数执行后返回值是 Promise
+      if (isPromise(bool)) {
+        return <PromiseRender ok={target} error={Exception} promise={bool} />;
+      }
       if (bool) {
-        // 函数执行后返回值是 Promise
-        if (isPromise(bool)) {
-          return <PromiseRender ok={target} error={Exception} promise={bool} />;
-        }
         return target;
       }
       return Exception;

--- a/src/components/Authorized/CheckPermissions.js
+++ b/src/components/Authorized/CheckPermissions.js
@@ -52,6 +52,10 @@ const checkPermissions = (authority, currentAuthority, target, Exception) => {
       if (bool) {
         return target;
       }
+      // 函数执行后返回值是 Promise
+      if (isPromise(bool)) {
+        return <PromiseRender ok={target} error={Exception} promise={bool} />;
+      }
       return Exception;
     } catch (error) {
       throw error;

--- a/src/components/Authorized/CheckPermissions.js
+++ b/src/components/Authorized/CheckPermissions.js
@@ -50,11 +50,11 @@ const checkPermissions = (authority, currentAuthority, target, Exception) => {
     try {
       const bool = authority(currentAuthority);
       if (bool) {
+        // 函数执行后返回值是 Promise
+        if (isPromise(bool)) {
+          return <PromiseRender ok={target} error={Exception} promise={bool} />;
+        }
         return target;
-      }
-      // 函数执行后返回值是 Promise
-      if (isPromise(bool)) {
-        return <PromiseRender ok={target} error={Exception} promise={bool} />;
       }
       return Exception;
     } catch (error) {

--- a/src/components/Authorized/index.md
+++ b/src/components/Authorized/index.md
@@ -25,14 +25,14 @@ order: 15
 | 参数      | 说明                                      | 类型         | 默认值 |
 |----------|------------------------------------------|-------------|-------|
 | children    | 正常渲染的元素，权限判断通过时展示           | ReactNode  | - |
-| authority   | 准入权限/权限判断         | `string | array | Promise | (currentAuthority) => boolean` | - |
+| authority   | 准入权限/权限判断         | `string | array | Promise | (currentAuthority) => boolean | Promise` | - |
 | noMatch     | 权限异常渲染元素，权限判断不通过时展示        | ReactNode  | - |
 
 ### Authorized.AuthorizedRoute
 
 | 参数      | 说明                                      | 类型         | 默认值 |
 |----------|------------------------------------------|-------------|-------|
-| authority     | 准入权限/权限判断         | `string | array | Promise | (currentAuthority) => boolean` | - |
+| authority     | 准入权限/权限判断         | `string | array | Promise | (currentAuthority) => boolean | Promise` | - |
 | redirectPath  | 权限异常时重定向的页面路由                | string  | - |
 
 其余参数与 `Route` 相同。
@@ -43,16 +43,16 @@ order: 15
 
 | 参数      | 说明                                      | 类型         | 默认值 |
 |----------|------------------------------------------|-------------|-------|
-| authority     | 准入权限/权限判断         | `string | Promise | (currentAuthority) => boolean` | - |
+| authority     | 准入权限/权限判断         | `string | Promise | (currentAuthority) => boolean | Promise` | - |
 | error  | 权限异常时渲染元素                |  ReactNode | <Exception type="403" /> |
 
 ### Authorized.check
 
-函数形式的 Authorized，用于某些不能被 HOC 包裹的组件。 `Authorized.check(authority, target, Exception)`  
+函数形式的 Authorized，用于某些不能被 HOC 包裹的组件。 `Authorized.check(authority, target, Exception)`
 注意：传入一个 Promise 时，无论正确还是错误返回的都是一个 ReactClass。
 
 | 参数      | 说明                                      | 类型         | 默认值 |
 |----------|------------------------------------------|-------------|-------|
-| authority     | 准入权限/权限判断         | `string | Promise | (currentAuthority) => boolean` | - |
+| authority     | 准入权限/权限判断         | `string | Promise | (currentAuthority) => boolean | Promise` | - |
 | target     | 权限判断通过时渲染的元素         | ReactNode | - |
 | Exception  | 权限异常时渲染元素                |  ReactNode | - |


### PR DESCRIPTION
Promise the execution, The status not again changes. quit & login authority result also not again changes. This is a mistake.

but authority is a function . After performing return Promise. There will be no such problem.

so if authority is a function . After performing return Promise. After performing return Promise is render component, Realize dynamic verification 。

由于 Promise 执行后的状态不可变更，如果 authority 配置 直接传入一个 Promise 来做权限验证时，只会得到第一次执行的结果。退出登录其它帐号，验证也不会改变。

如果在传入函数的情况下，让其返回一个 Promise 就不会存在这个问题。所以在 传入函数时，也验证一次结果是不是 Promise 让它去 渲染 ，从而实现动态验证。


------

我直接将 master 重置成了远端主仓库的版本，然后在 master 重新再改了一遍，再试一次把，抱歉，添麻烦了。
如果不行就只能靠你们自己改一下了？。。 😢