### PR TITLE
fix: judgment condition of autoHideHeader state

### DIFF
--- a/src/components/SettingDarwer/index.js
+++ b/src/components/SettingDarwer/index.js
@@ -94,7 +94,7 @@ class SettingDarwer extends PureComponent {
       }
     }
     if (key === 'fixedHeader') {
-      if (value) {
+      if (!value) {
         nextState.autoHideHeader = false;
       }
     }


### PR DESCRIPTION
应该在禁用 fixedHeader 属性时禁用 autoHideHeader 