### PR TITLE
fix: isUrl func failed && support judge url with port

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -162,7 +162,7 @@ export function getRoutes(path, routerData) {
 }
 
 /* eslint no-useless-escape:0 */
-const reg = /(((^https?:(?:\/\/)?)(?:[-;:&=\+\$,\w]+@)?[A-Za-z0-9.-]+|(?:www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:\/[\+~%\/.\w-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*))?)$/g;
+const reg = /(((^https?:(?:\/\/)?)(?:[-;:&=\+\$,\w]+@)?[A-Za-z0-9.-]+(?::\d+)?|(?:www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:\/[\+~%\/.\w-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*))?)$/;
 
 export function isUrl(path) {
   return reg.test(path);


### PR DESCRIPTION
The reg use global tag will result in wrong judgement because it will remember the lastIndex of the same string, and the reg didn't think about the situation when url with port 

before:
```javascript
isUrl('http://xxx.xxx.xxx')
// => true
isUrl('http://xxx.xxx.xxx')
// => false

isUrl('http://192.168.1.1:8011')
// => false
```

after:
```javascript
isUrl('http://xxx.xxx.xxx')
// => true
isUrl('http://xxx.xxx.xxx')
// => true

isUrl('http://192.168.1.1:8011')
// => true
```