### PR TITLE
Compatible with IE10

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,14 +45,15 @@
     "react-dom": "^16.4.1",
     "react-fittext": "^1.0.0",
     "rollbar": "^2.3.4",
+    "setprototypeof": "^1.1.0",
     "url-polyfill": "^1.0.10"
   },
   "devDependencies": {
     "babel-eslint": "^8.1.2",
     "babel-plugin-dva-hmr": "^0.4.1",
     "babel-plugin-import": "^1.6.7",
-    "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-module-resolver": "^3.1.1",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "cross-env": "^5.1.1",
     "cross-port-killer": "^1.0.1",
     "enzyme": "^3.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
-import '@babel/polyfill';
-import 'url-polyfill';
+import './polyfill';
 import dva from 'dva';
 
 import createHistory from 'history/createHashHistory';

--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -1,0 +1,12 @@
+import '@babel/polyfill';
+import 'url-polyfill';
+import setprototypeof from 'setprototypeof';
+
+// React depends on set/map/requestAnimationFrame
+// https://reactjs.org/docs/javascript-environment-requirements.html
+// import 'core-js/es6/set';
+// import 'core-js/es6/map';
+// import 'raf/polyfill'; 只兼容到IE10不需要，况且fetch的polyfill whatwg-fetch也只兼容到IE10
+
+// https://github.com/umijs/umi/issues/413
+Object.setPrototypeOf = setprototypeof;


### PR DESCRIPTION
Only compatible with IE10+ because fetch polyfill [whatwg-fetch](https://github.com/github/fetch) is only compatible with IE10+.

Related:
umijs/umi/issues/413
umijs/umi/issues/544
dvajs/dva/issues/1677
dvajs/dva/issues/1717
ant-design/ant-design-pro/issues/331
ant-design/ant-design-pro/issues/1030
ant-design/ant-design-pro/issues/1396
ant-design/ant-design-pro/issues/1419
ant-design/ant-design-pro/issues/1501
ant-design/ant-design-pro/issues/1679
babel/babel/pull/7969

