### PR TITLE
feat: migrate to umi

### DIFF
--- a/mock/api.js
+++ b/mock/api.js
@@ -1,3 +1,5 @@
+import mockjs from 'mockjs';
+
 const titles = [
   'Alipay',
   'Angular',
@@ -59,7 +61,7 @@ const user = [
   '仲尼',
 ];
 
-export function fakeList(count) {
+function fakeList(count) {
   const list = [];
   for (let i = 0; i < count; i += 1) {
     list.push({
@@ -109,7 +111,7 @@ export function fakeList(count) {
 
 let sourceData;
 
-export function getFakeList(req, res) {
+function getFakeList(req, res) {
   const params = req.query;
 
   const count = params.count * 1 || 20;
@@ -124,7 +126,7 @@ export function getFakeList(req, res) {
   }
 }
 
-export function postFakeList(req, res) {
+function postFakeList(req, res) {
   const { /* url = '', */ body } = req;
   // const params = getUrlParams(url);
   const { method, id } = body;
@@ -160,7 +162,7 @@ export function postFakeList(req, res) {
   }
 }
 
-export const getNotice = [
+const getNotice = [
   {
     id: 'xxx1',
     title: titles[0],
@@ -223,7 +225,7 @@ export const getNotice = [
   },
 ];
 
-export const getActivities = [
+const getActivities = [
   {
     id: 'trend-1',
     updatedAt: new Date(),
@@ -324,7 +326,7 @@ export const getActivities = [
   },
 ];
 
-export function getFakeCaptcha(req, res) {
+function getFakeCaptcha(req, res) {
   if (res && res.json) {
     res.json('captcha-xxx');
   } else {
@@ -333,9 +335,15 @@ export function getFakeCaptcha(req, res) {
 }
 
 export default {
-  getNotice,
-  getActivities,
-  getFakeList,
-  postFakeList,
-  getFakeCaptcha,
+  'GET /api/project/notice': getNotice,
+  'GET /api/activities': getActivities,
+  'POST /api/forms': (req, res) => {
+    res.send({ message: 'Ok' });
+  },
+  'GET /api/tags': mockjs.mock({
+    'list|100': [{ name: '@city', 'value|1-100': 150, 'type|0-2': 1 }],
+  }),
+  'GET /api/fake_list': getFakeList,
+  'POST /api/fake_list': postFakeList,
+  'GET /api/captcha': getFakeCaptcha,
 };

--- a/mock/chart.js
+++ b/mock/chart.js
@@ -179,7 +179,7 @@ radarOriginData.forEach(item => {
   });
 });
 
-export const getFakeChartData = {
+const getFakeChartData = {
   visitData,
   visitData2,
   salesData,
@@ -193,5 +193,5 @@ export const getFakeChartData = {
 };
 
 export default {
-  getFakeChartData,
+  'GET /api/fake_chart_data': getFakeChartData,
 };

--- a/mock/geographic.js
+++ b/mock/geographic.js
@@ -1,15 +1,15 @@
 import city from './geographic/city.json';
 import province from './geographic/province.json';
 
-export function getProvince(req, res) {
+function getProvince(req, res) {
   res.json(province);
 }
 
-export function getCity(req, res) {
+function getCity(req, res) {
   res.json(city[req.params.province]);
 }
 
 export default {
-  getProvince,
-  getCity,
+  'GET /api/geographic/province': getProvince,
+  'GET /api/geographic/city/:province': getCity,
 };

--- a/mock/notices.js
+++ b/mock/notices.js
@@ -1,4 +1,4 @@
-export const getNotices = (req, res) => {
+const getNotices = (req, res) => {
   res.json([
     {
       id: '000000001',
@@ -94,6 +94,7 @@ export const getNotices = (req, res) => {
     },
   ]);
 };
+
 export default {
-  getNotices,
+  'GET /api/notices': getNotices,
 };

--- a/mock/profile.js
+++ b/mock/profile.js
@@ -141,18 +141,18 @@ const advancedOperation3 = [
   },
 ];
 
-export const getProfileBasicData = {
+const getProfileBasicData = {
   basicGoods,
   basicProgress,
 };
 
-export const getProfileAdvancedData = {
+const getProfileAdvancedData = {
   advancedOperation1,
   advancedOperation2,
   advancedOperation3,
 };
 
 export default {
-  getProfileBasicData,
-  getProfileAdvancedData,
+  'GET /api/profile/advanced': getProfileAdvancedData,
+  'GET /api/profile/basic': getProfileBasicData,
 };

--- a/mock/rule.js
+++ b/mock/rule.js
@@ -23,7 +23,7 @@ for (let i = 0; i < 46; i += 1) {
   });
 }
 
-export function getRule(req, res, u) {
+function getRule(req, res, u) {
   let url = u;
   if (!url || Object.prototype.toString.call(url) !== '[object String]') {
     url = req.url; // eslint-disable-line
@@ -79,7 +79,7 @@ export function getRule(req, res, u) {
   }
 }
 
-export function postRule(req, res, u, b) {
+function postRule(req, res, u, b) {
   let url = u;
   if (!url || Object.prototype.toString.call(url) !== '[object String]') {
     url = req.url; // eslint-disable-line
@@ -141,6 +141,6 @@ export function postRule(req, res, u, b) {
 }
 
 export default {
-  getRule,
-  postRule,
+  'GET /api/rule': getRule,
+  'POST /api/rule': postRule,
 };

--- a/mock/user.js
+++ b/mock/user.js
@@ -1,17 +1,5 @@
-import mockjs from 'mockjs';
-import { getRule, postRule } from './mock/rule';
-import { getActivities, getNotice, getFakeList, postFakeList, getFakeCaptcha } from './mock/api';
-import { getFakeChartData } from './mock/chart';
-import { getProfileBasicData } from './mock/profile';
-import { getProfileAdvancedData } from './mock/profile';
-import { getNotices } from './mock/notices';
-import { getProvince, getCity } from './mock/geographic';
-
-// 是否禁用代理
-const noProxy = process.env.NO_PROXY === 'true';
-
 // 代码中会兼容本地 service mock 以及部署站点的静态数据
-const proxy = {
+export default {
   // 支持值为 Object 和 Array
   'GET /api/currentUser': {
     name: 'Serati Ma',
@@ -83,21 +71,6 @@ const proxy = {
       address: 'Sidney No. 1 Lake Park',
     },
   ],
-  'GET /api/project/notice': getNotice,
-  'GET /api/activities': getActivities,
-  'GET /api/rule': getRule,
-  'POST /api/rule': postRule,
-  'POST /api/forms': (req, res) => {
-    res.send({ message: 'Ok' });
-  },
-  'GET /api/tags': mockjs.mock({
-    'list|100': [{ name: '@city', 'value|1-100': 150, 'type|0-2': 1 }],
-  }),
-  'GET /api/fake_list': getFakeList,
-  'POST /api/fake_list': postFakeList,
-  'GET /api/fake_chart_data': getFakeChartData,
-  'GET /api/profile/basic': getProfileBasicData,
-  'GET /api/profile/advanced': getProfileAdvancedData,
   'POST /api/login/account': (req, res) => {
     const { password, userName, type } = req.body;
     if (password === '888888' && userName === 'admin') {
@@ -125,7 +98,6 @@ const proxy = {
   'POST /api/register': (req, res) => {
     res.send({ status: 'ok', currentAuthority: 'user' });
   },
-  'GET /api/notices': getNotices,
   'GET /api/500': (req, res) => {
     res.status(500).send({
       timestamp: 1513932555104,
@@ -162,9 +134,4 @@ const proxy = {
       path: '/base/category/list',
     });
   },
-  'GET /api/geographic/province': getProvince,
-  'GET /api/geographic/city/:province': getCity,
-  'GET /api/captcha': getFakeCaptcha,
 };
-
-export default (noProxy ? {} : proxy);


### PR DESCRIPTION
https://github.com/ant-design/ant-design-pro/issues/1512

- [x] 路由
- [x] 样式
- [x] dva model
- [ ] 主题切换
- [ ] eslint 切换到 eslint-config-umi
- [x] mock 数据
- [ ] 静态资源
- [ ] 单元测试使用 umi test
- [ ] 动态加载
- [ ] 文档
- [ ] 国际化相关
- [ ] 权限，权限路由
- [ ] 404 页面
- [ ] title
- [x] menu
- [x] 个人页
- [x] 设置页
- [x] 登录注册页
- [ ] 布局样式错误，页面过窄时下方留白
- [x] 初始化页面（路由 / 对应的页面）
- [ ] 冲突 fix
- [x] mock 改为约定式（去掉 umirc.mock.js）
- [ ] 删除注释的老代码
- [ ] e2e test
- [ ] build
- [ ] /trigger
- [ ] 优化 common/menu 和 common/router 代码

没有做太多的代码修改，调整了一下目录结构。对会阻塞掉运行的一些地方做了简单的修改，便于后续基于该版本快速分工迭代。

![image](https://user-images.githubusercontent.com/1061968/42220775-95a56058-7f02-11e8-9991-902a736903c0.png)

该 PR 做的修改有：

- 去掉 roadhog，添加 umi 依赖
- 去掉 dva，添加 umi-plugin-dva 依赖
- 添加 config/config.js 并把 webpackrc.js 合并到里面
- 修改 routes 目录为 pages，并修改对应代码中的引用路径
- 去掉 models/index.js，在 umi 中 models 下的 model 会自动挂载
- `src/index.ejs` 修改为 umi 约定的 s`rc/pages/document.js`

