### PR TITLE
mkdir改成同步方法

### DIFF
--- a/scripts/mergeLessPlugin.js
+++ b/scripts/mergeLessPlugin.js
@@ -60,7 +60,7 @@ class mergeLessPlugin {
       if (fs.existsSync(outFile)) {
         fs.unlinkSync(outFile);
       } else {
-        fs.mkdir(path.dirname(outFile));
+        fs.mkdirSync(path.dirname(outFile));
       }
       loopAllLess(options.stylesDir).then(() => {
         fs.writeFileSync(outFile, lessArray.join('\n'));


### PR DESCRIPTION
在jenkins上跑的时候发现了这个问题。会因为fs.mkdir是异步方法导致报错。