### PR TITLE
包装一下Modal，提供部分默认行为和垂直居中模式

### DIFF
--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -1,0 +1,166 @@
+import React, { Component } from 'react';
+import { Modal, Spin } from 'antd';
+import classNames from 'classnames';
+import style from './index.less';
+
+export default class CustModal extends Component {
+  constructor(props) {
+    super(props);
+    this.timer = undefined;
+    this.state = {
+      modalProps: props,
+    };
+  }
+
+  defClose = () => {
+    const { modalProps } = this.state;
+    const { onVisibleChange } = this.props;
+    this.setState({
+      modalProps: {
+        ...modalProps,
+        loading: false,
+        visible: false,
+        confirmLoading: false,
+      },
+    });
+    if (onVisibleChange) {
+      onVisibleChange(false);
+    }
+    // 动画结束后清理，直接清理会可见闪烁
+    this.timer = setTimeout(() => {
+      this.clearTimer();
+      this.setState({
+        modalProps: {},
+      });
+    }, 500);
+  };
+
+  defOk = onOk => {
+    return () => {
+      if (onOk == null) {
+        this.defClose();
+        return;
+      }
+      const { modalProps } = this.state;
+      this.setState({
+        modalProps: {
+          ...modalProps,
+          confirmLoading: true,
+        },
+      });
+      const result = onOk({
+        close: this.defClose,
+      });
+      if (result === false) {
+        return;
+      }
+      if (result === undefined) {
+        this.defClose();
+      }
+    };
+  };
+
+  clearTimer() {
+    if (this.timer) {
+      window.clearTimeout(this.timer);
+    }
+    this.timer = null;
+  }
+
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    const { modalProps } = this.state;
+    const { children: nextChildren, visible } = nextProps;
+    if (visible) {
+      this.clearTimer();
+    }
+    // 如果children不传，使用原来的，for loading
+    const { children: oChildren } = modalProps;
+    let children = oChildren;
+    if (nextChildren != null) {
+      children = nextChildren;
+    }
+    this.setState({
+      modalProps: {
+        ...modalProps,
+        ...nextProps,
+        children,
+      },
+    });
+  }
+
+  render() {
+    const { modalProps } = this.state;
+    const {
+      children,
+      onOk,
+      onCancel,
+      loading,
+      footer,
+      // centered = true,
+      centered,
+      wrapClassName,
+      ...rest
+    } = modalProps;
+    // 各自只能出现一次
+    let hasOk = false;
+    let hasCancel = false;
+    const okFn = this.defOk(onOk);
+    const props = {
+      destroyOnClose: true,
+      ...rest,
+      onCancel: onCancel || this.defClose,
+      onOk: okFn,
+      footer: React.Children.map(footer, child => {
+        if (child) {
+          const { link, children: ch, ...restProps } = child.props;
+          if (link) {
+            // link 后 也携带事件？
+            // const onClick = restProps.onClick;
+            switch (link) {
+              case 'ok':
+                if (!hasOk) {
+                  hasOk = true;
+                  return React.cloneElement(child, {
+                    type: modalProps.okType,
+                    ...restProps,
+                    ...modalProps.okButtonProps,
+                    children: ch || modalProps.okText || '确定',
+                    onClick: okFn,
+                  });
+                }
+                break;
+              case 'cancel':
+                if (!hasCancel) {
+                  hasCancel = true;
+                  return React.cloneElement(child, {
+                    ...restProps,
+                    ...modalProps.cancelButtonProps,
+                    children: ch || modalProps.cancelText || '取消',
+                    onClick: onCancel || this.defClose,
+                  });
+                }
+                break;
+              default:
+            }
+          }
+        }
+        return child;
+      }),
+    };
+    return (
+      <Modal
+        wrapClassName={classNames(
+          {
+            [style.verticalCenter]: centered,
+            'vertical-center-modal': centered,
+          },
+          wrapClassName
+        )}
+        {...props}
+      >
+        {loading ? <Spin>{children}</Spin> : children}
+      </Modal>
+    );
+  }
+}

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -41,22 +41,36 @@ export default class CustModal extends Component {
         this.defClose();
         return;
       }
-      const { modalProps } = this.state;
-      this.setState({
-        modalProps: {
-          ...modalProps,
-          confirmLoading: true,
-        },
-      });
-      const result = onOk({
-        close: this.defClose,
-      });
-      if (result === false) {
-        return;
-      }
-      if (result === undefined) {
-        this.defClose();
-      }
+      this.setState(
+        ({ modalProps }) => ({
+          modalProps: {
+            ...modalProps,
+            confirmLoading: true,
+          },
+        }),
+        () => {
+          const okResult = onOk({
+            close: this.defClose,
+          });
+          (okResult instanceof Promise ? okResult : Promise.resolve(okResult)).then(result => {
+            const { modalProps } = this.state;
+            setTimeout(() => {
+              this.setState({
+                modalProps: {
+                  ...modalProps,
+                  confirmLoading: false,
+                },
+              });
+            }, 0);
+            if (result === false) {
+              return;
+            }
+            if (result === undefined) {
+              this.defClose();
+            }
+          });
+        }
+      );
     };
   };
 
@@ -99,6 +113,7 @@ export default class CustModal extends Component {
       footer,
       // centered = true,
       centered,
+      confirmLoading,
       wrapClassName,
       ...rest
     } = modalProps;
@@ -109,6 +124,7 @@ export default class CustModal extends Component {
     const props = {
       destroyOnClose: true,
       ...rest,
+      confirmLoading,
       onCancel: onCancel || this.defClose,
       onOk: okFn,
       footer: React.Children.map(footer, child => {
@@ -125,6 +141,7 @@ export default class CustModal extends Component {
                     type: modalProps.okType,
                     ...restProps,
                     ...modalProps.okButtonProps,
+                    loading: confirmLoading,
                     children: ch || modalProps.okText || '确定',
                     onClick: okFn,
                   });

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -12,6 +12,10 @@ export default class CustModal extends Component {
     };
   }
 
+  componentWillUnmount() {
+    this.isUnmounted = true;
+  }
+
   defClose = () => {
     const { modalProps } = this.state;
     const { onVisibleChange } = this.props;
@@ -29,10 +33,13 @@ export default class CustModal extends Component {
     // 动画结束后清理，直接清理会可见闪烁
     this.timer = setTimeout(() => {
       this.clearTimer();
+      if (this.isUnmounted) {
+        return;
+      }
       this.setState({
         modalProps: {},
       });
-    }, 500);
+    }, 300);
   };
 
   defOk = onOk => {
@@ -53,16 +60,16 @@ export default class CustModal extends Component {
             close: this.defClose,
           });
           (okResult instanceof Promise ? okResult : Promise.resolve(okResult)).then(result => {
-            const { modalProps } = this.state;
-            setTimeout(() => {
-              this.setState({
-                modalProps: {
-                  ...modalProps,
-                  confirmLoading: false,
-                },
-              });
-            }, 0);
             if (result === false) {
+              const { modalProps } = this.state;
+              setTimeout(() => {
+                this.setState({
+                  modalProps: {
+                    ...modalProps,
+                    confirmLoading: false,
+                  },
+                });
+              }, 0);
               return;
             }
             if (result === undefined) {

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -16,6 +16,16 @@ export default class CustModal extends Component {
     this.isUnmounted = true;
   }
 
+  setConfirmLoading = confirmLoading => {
+    const { modalProps } = this.state;
+    this.setState({
+      modalProps: {
+        ...modalProps,
+        confirmLoading,
+      },
+    });
+  };
+
   defClose = () => {
     const { modalProps } = this.state;
     const { onVisibleChange } = this.props;
@@ -58,17 +68,12 @@ export default class CustModal extends Component {
         () => {
           const okResult = onOk({
             close: this.defClose,
+            setConfirmLoading: this.setConfirmLoading,
           });
           (okResult instanceof Promise ? okResult : Promise.resolve(okResult)).then(result => {
             if (result === false) {
-              const { modalProps } = this.state;
               setTimeout(() => {
-                this.setState({
-                  modalProps: {
-                    ...modalProps,
-                    confirmLoading: false,
-                  },
-                });
+                this.setConfirmLoading(false);
               }, 0);
               return;
             }

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -52,7 +52,7 @@ export default class CustModal extends Component {
     }, 300);
   };
 
-  defOk = onOk => {
+  defOk = (onOk, ...rest) => {
     return () => {
       if (onOk == null) {
         this.defClose();
@@ -66,10 +66,16 @@ export default class CustModal extends Component {
           },
         }),
         () => {
-          const okResult = onOk({
-            close: this.defClose,
-            setConfirmLoading: this.setConfirmLoading,
-          });
+          const okResult = onOk(
+            {
+              close: this.defClose,
+              setConfirmLoading: this.setConfirmLoading,
+              deepCallOk: (ok, ...r) => {
+                this.defOk(ok, ...r)();
+              },
+            },
+            ...rest
+          );
           (okResult instanceof Promise ? okResult : Promise.resolve(okResult)).then(result => {
             if (result === false) {
               setTimeout(() => {

--- a/src/components/Modal/index.less
+++ b/src/components/Modal/index.less
@@ -1,0 +1,44 @@
+/* use css to set position of modal */
+
+// vertical-center-modal name for antd Modal less
+// @media (max-width: @screen-sm-max) {
+//   .@{dialog-prefix-cls} {
+//     width: auto !important;
+//     margin: 10px;
+//   }
+//   .vertical-center-modal {
+//     .@{dialog-prefix-cls} {
+//       flex: 1;
+//     }
+//   }
+// }
+.verticalCenter:global(.vertical-center-modal) {
+  text-align: center;
+  white-space: nowrap;
+  &:before {
+    content: '';
+    display: inline-block;
+    height: 100%;
+    vertical-align: middle;
+    width: 0;
+  }
+  :global(.ant-modal) {
+    display: inline-block;
+    vertical-align: middle;
+    top: 0;
+    text-align: left;
+  }
+}
+
+/*
+// Use flex which not working in IE
+.vertical-center-modal {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.vertical-center-modal .ant-modal {
+  top: 0;
+}
+*/

--- a/src/components/Modal/index.less
+++ b/src/components/Modal/index.less
@@ -21,15 +21,17 @@
     vertical-align: middle;
     width: 0;
   }
-  :global(.ant-modal) {
-    display: inline-block;
-    vertical-align: middle;
-    top: 0;
-    text-align: left;
-  }
-  .ant-table-body {
-    white-space: nowrap;
-    overflow-x: auto;
+  :global {
+    .ant-modal {
+      display: inline-block;
+      vertical-align: middle;
+      top: 0;
+      text-align: left;
+    }
+    .ant-table-body {
+      white-space: nowrap;
+      overflow-x: auto;
+    }
   }
 }
 

--- a/src/components/Modal/index.less
+++ b/src/components/Modal/index.less
@@ -14,7 +14,6 @@
 // }
 .verticalCenter:global(.vertical-center-modal) {
   text-align: center;
-  white-space: nowrap;
   &:before {
     content: '';
     display: inline-block;
@@ -27,6 +26,10 @@
     vertical-align: middle;
     top: 0;
     text-align: left;
+  }
+  .ant-table-body {
+    white-space: nowrap;
+    overflow-x: auto;
   }
 }
 


### PR DESCRIPTION
包装一下Modal，提供部分默认行为和垂直居中模式;

如果使用垂直居中模式，你可能还需要如下样式来获得更好的宽度溢出控制，相关issue: ant-design/ant-design#11359
```less
.ant-modal-wrap {
  .ant-modal {
    padding-bottom: 0;
  }
}

// https://github.com/ant-design/ant-design/issues/11359
.ant-modal-body {
  max-height: calc(~'100vh - 55px - 53px');
  max-width: calc(~'100vw - 20px');
  overflow-y: auto;
}

@media (max-width: @screen-sm-max) {
  .ant-modal-body {
    max-height: calc(~'100vh - 55px - 53px - 20px');
  }
}

```