### PR TITLE
 Runtime pass props `hideInBreadcrumb`

### DIFF
--- a/src/components/PageHeader/index.js
+++ b/src/components/PageHeader/index.js
@@ -66,6 +66,10 @@ export default class PageHeader extends PureComponent {
   };
 
   getBreadcrumbDom = () => {
+    const { hideInBreadcrumb } = this.props;
+    if (hideInBreadcrumb) {
+      return;
+    }
     const breadcrumb = this.conversionBreadcrumbList();
     this.setState({
       breadcrumb,


### PR DESCRIPTION
Support for runtime pass props `hideInBreadcrumb` to hide breadcrumbs.