### PR TITLE
fix: use max-height to replace height for better vertical-align

### DIFF
--- a/src/components/Charts/Pie/index.less
+++ b/src/components/Charts/Pie/index.less
@@ -61,7 +61,7 @@
     left: 50%;
     top: 50%;
     text-align: center;
-    height: 62px;
+    max-height: 62px;
     transform: translate(-50%, -50%);
     & > h4 {
       color: @text-color-secondary;


### PR DESCRIPTION
## Problem
```
<Pie subTitle="Im subTitle"  />
```

![image](https://user-images.githubusercontent.com/5318333/43189743-e52a354e-9029-11e8-8708-000eefc9b33e.png)


The subTitle don't align to center vertically for `height: 62px` https://github.com/ant-design/ant-design-pro/blob/master/src/components/Charts/Pie/index.less#L64

## Maybe

Pie.total has a css property` transform(-50%, -50%)`, which can calculate position base on the real height, so I think there's no need to lock the height of Pie.total, If want to control the content, max-height is better