### PR TITLE
feat: export bizcharts

### DIFF
--- a/src/components/Charts/bizcharts.d.ts
+++ b/src/components/Charts/bizcharts.d.ts
@@ -1,3 +1,3 @@
 import * as BizChart from 'bizcharts';
 
-export default BizChart;
+export = BizChart;

--- a/src/components/Charts/bizcharts.js
+++ b/src/components/Charts/bizcharts.js
@@ -1,0 +1,2 @@
+import * as BizChart from 'bizcharts';
+export default BizChart;


### PR DESCRIPTION
sometimes need to use both bizChart and antd-pro in project, and If I keep `ant-design-pro` and `bizcharts` the same time in project's `package.json.dependencies`, that will bring multi-version of g2

so export bizcharts using interface like
`import bz from 'ant-design-pro/lib/Charts/bizcharts`
