### PR TITLE
[BugFix] Fix chart data type and requirement

### DIFF
--- a/src/components/Charts/TimelineChart/index.d.ts
+++ b/src/components/Charts/TimelineChart/index.d.ts
@@ -1,11 +1,11 @@
 import * as React from 'react';
 export interface ITimelineChartProps {
   data: Array<{
-    x: string;
-    y1: string;
-    y2: string;
+    x: number;
+    y1: number;
+    y2?: number;
   }>;
-  titleMap: { y1: string; y2: string };
+  titleMap: { y1: string; y2?: string };
   padding?: [number, number, number, number];
   height?: number;
   style?: React.CSSProperties;


### PR DESCRIPTION
By watching TimelineChart Example:
[Charts Demo](https://pro.ant.design/components/Charts#scaffold-src-components-Charts-demo-mini-area)

```javascript
const chartData = [];
for (let i = 0; i < 20; i += 1) {
  chartData.push({
    x: (new Date().getTime()) + (1000 * 60 * 30 * i),
    y1: Math.floor(Math.random() * 100) + 1000,
    y2: Math.floor(Math.random() * 100) + 10,
  });
}
```

1. X-Axis (Timeline): The type should be like `number`.
2. Y-Axis (Value): The y2 may not be required if I just want to draw y1 only.