### PR TITLE
fix title: Break the loop and avoid being overwritten

### DIFF
--- a/src/layouts/BasicLayout.js
+++ b/src/layouts/BasicLayout.js
@@ -134,10 +134,12 @@ export default class BasicLayout extends React.PureComponent {
     let title = 'Ant Design Pro';
     let currRouterData = null;
     // match params path
-    Object.keys(routerData).forEach(key => {
+    Object.keys(routerData).some(key => {
       if (pathToRegexp(key).test(pathname)) {
         currRouterData = routerData[key];
+        return true;
       }
+      return false;
     });
     if (currRouterData && currRouterData.name) {
       title = `${currRouterData.name} - Ant Design Pro`;

--- a/src/layouts/BasicLayout.js
+++ b/src/layouts/BasicLayout.js
@@ -132,15 +132,10 @@ export default class BasicLayout extends React.PureComponent {
     const { routerData, location } = this.props;
     const { pathname } = location;
     let title = 'Ant Design Pro';
-    let currRouterData = null;
     // match params path
-    Object.keys(routerData).some(key => {
-      if (pathToRegexp(key).test(pathname)) {
-        currRouterData = routerData[key];
-        return true;
-      }
-      return false;
-    });
+    const currRouterData = (Object.entries(routerData).find(([key]) =>
+      pathToRegexp(key).test(pathname)
+    ) || [])[1];
     if (currRouterData && currRouterData.name) {
       title = `${currRouterData.name} - Ant Design Pro`;
     }

--- a/src/layouts/BasicLayout.js
+++ b/src/layouts/BasicLayout.js
@@ -132,10 +132,14 @@ export default class BasicLayout extends React.PureComponent {
     const { routerData, location } = this.props;
     const { pathname } = location;
     let title = 'Ant Design Pro';
+    let currRouterData = null;
     // match params path
-    const currRouterData = (Object.entries(routerData).find(([key]) =>
-      pathToRegexp(key).test(pathname)
-    ) || [])[1];
+    for (key in Object.keys(routerData)) {
+      if (pathToRegexp(key).test(pathname)) {
+        currRouterData = routerData[key];
+        break
+      }
+    }
     if (currRouterData && currRouterData.name) {
       title = `${currRouterData.name} - Ant Design Pro`;
     }


### PR DESCRIPTION
首次匹配终止循环，提高性能并避免被二次相似规则匹配覆盖,如：
```
/basic/deal/pubservice
```
```
/basic/deal/:id
```
