### PR TITLE
Add missing colors prop in Pie Chart index.d.ts

### DIFF
--- a/src/components/Charts/Pie/index.d.ts
+++ b/src/components/Charts/Pie/index.d.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 export interface IPieProps {
   animate?: boolean;
   color?: string;
+  colors?: string[];
   height: number;
   hasLegend?: boolean;
   padding?: [number, number, number, number];


### PR DESCRIPTION
the property colors?: string[] was missing in the typescript definitions