### PR TITLE
remove babel polyfill

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -22,7 +22,7 @@ export default {
         dynamicImport: {
           loadingComponent: './components/PageLoading/index',
         },
-        polyfills: ['ie9'],
+        polyfills: ['ie11'],
         ...(!process.env.TEST && os.platform() === 'darwin'
           ? {
               dll: ['dva', 'dva/router', 'dva/saga', 'dva/fetch'],

--- a/config/config.js
+++ b/config/config.js
@@ -22,7 +22,7 @@ export default {
         dynamicImport: {
           loadingComponent: './components/PageLoading/index',
         },
-        polyfills: ['ie11'],
+        polyfills: ['ie9'],
         ...(!process.env.TEST && os.platform() === 'darwin'
           ? {
               dll: ['dva', 'dva/router', 'dva/saga', 'dva/fetch'],

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "dependencies": {
     "@antv/data-set": "^0.9.0",
-    "@babel/polyfill": "^7.0.0",
     "@babel/runtime": "^7.0.0",
     "antd": "^3.9.0",
     "bizcharts": "^3.1.10",

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
     "react-router-dom": "^4.3.1"
   },
   "devDependencies": {
-    "umi": "^2.0.0",
-    "umi-plugin-react": "^1.0.0",
+    "umi": "^2.0.1",
+    "umi-plugin-react": "^1.0.1",
     "@types/react": "^16.4.11",
     "@types/react-dom": "^16.0.6",
     "antd-pro-merge-less": "^0.0.9",

--- a/src/global.js
+++ b/src/global.js
@@ -1,1 +1,0 @@
-import '@babel/polyfill';


### PR DESCRIPTION
应用应该不用自己引 polyfill。

@chenshuai2144 可以说下加这个为了啥。

@sorrycc 看看有什么问题。

---

如果是解决 https://github.com/ant-design/ant-design-pro/issues/2125 的 Number.isNaN 的问题，@sorrycc 看看是不是 polyfills ie9 或者 ie11 里面漏了。