### PR TITLE
fix: dll and analyze

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -25,7 +25,10 @@ export default {
         polyfills: ['ie11'],
         ...(!process.env.TEST && os.platform() === 'darwin'
           ? {
-              dll: ['dva', 'dva/router', 'dva/saga', 'dva/fetch'],
+              dll: {
+                include: ['dva', 'dva/router', 'dva/saga', 'dva/fetch'],
+                exclude: ['@babel/runtime'],
+              },
               hardSource: true,
             }
           : {}),

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "precommit": "npm run lint-staged",
     "presite": "npm run generate-mock && cd functions && npm install",
-    "start": "cross-env APP_TYPE=site ANALYZE=1 umi dev",
+    "start": "cross-env APP_TYPE=site umi dev",
     "start:no-mock": "cross-env MOCK=none umi dev",
     "build": "umi build",
     "site": "npm run presite && cross-env APP_TYPE=site npm run build && firebase deploy",


### PR DESCRIPTION

* dll 配置不对
* dll 需 exclude `@babel/runtime`
* `umi dev` 时现在不能启用 `ANALYZE=1`，因为 dll 也会开启，待 umi 修复这个问题后再考虑
