### PR TITLE
fix: Export AuthorizedProps

### DIFF
--- a/src/components/Authorized/index.d.ts
+++ b/src/components/Authorized/index.d.ts
@@ -27,7 +27,7 @@ interface check {
   ): T | S;
 }
 
-interface AuthorizedProps {
+export interface AuthorizedProps {
   authority: authority;
   noMatch?: React.ReactNode;
 }


### PR DESCRIPTION
`AuthorizedProps` is missing from module's exports.