### PR TITLE
fix: DescriptionList

### DIFF
--- a/src/components/DescriptionList/Description.js
+++ b/src/components/DescriptionList/Description.js
@@ -10,8 +10,7 @@ const Description = ({ term, column, className, children, ...restProps }) => {
   return (
     <Col className={clsString} {...responsive[column]} {...restProps}>
       {term && <div className={styles.term}>{term}</div>}
-      {children !== null &&
-        children !== undefined && <div className={styles.detail}>{children}</div>}
+      <div className={styles.detail}>{children || ''}</div>
     </Col>
   );
 };

--- a/src/components/DescriptionList/Description.js
+++ b/src/components/DescriptionList/Description.js
@@ -10,17 +10,19 @@ const Description = ({ term, column, className, children, ...restProps }) => {
   return (
     <Col className={clsString} {...responsive[column]} {...restProps}>
       {term && <div className={styles.term}>{term}</div>}
-      <div className={styles.detail}>{children || ''}</div>
+      <div className={styles.detail}>{children}</div>
     </Col>
   );
 };
 
 Description.defaultProps = {
   term: '',
+  children: '',
 };
 
 Description.propTypes = {
   term: PropTypes.node,
+  children: PropTypes.node,
 };
 
 export default Description;

--- a/src/components/DescriptionList/index.less
+++ b/src/components/DescriptionList/index.less
@@ -34,7 +34,11 @@
   }
 
   .detail {
-    line-height: 22px;
+    // Line-height is 22px IE dom height will calculate error
+    line-height: 20px;
+    // Prevent layout disorder
+    min-height: 20px;
+    box-sizing: content-box;
     width: 100%;
     padding-bottom: 16px;
     color: @text-color;


### PR DESCRIPTION
防止描述列表在详情空缺时布局错乱（因为内容可能不是纯文本，所以很难控制内容高度不一致时的布局问题）