### PR TITLE
fix: Pie chart percent prop default value

### DIFF
--- a/src/components/Charts/Pie/index.js
+++ b/src/components/Charts/Pie/index.js
@@ -167,7 +167,7 @@ class Pie extends Component {
       },
     };
 
-    if (percent) {
+    if (percent || percent === 0) {
       selected = false;
       tooltip = false;
       formatColor = value => {
@@ -227,7 +227,7 @@ class Pie extends Component {
                 tooltip={tooltip && tooltipFormat}
                 type="intervalStack"
                 position="percent"
-                color={['x', percent ? formatColor : defaultColors]}
+                color={['x', percent || percent === 0 ? formatColor : defaultColors]}
                 selected={selected}
               />
             </Chart>

--- a/src/components/Charts/Pie/index.js
+++ b/src/components/Charts/Pie/index.js
@@ -127,7 +127,7 @@ class Pie extends Component {
       style,
       height,
       forceFit = true,
-      percent = 0,
+      percent,
       color,
       inner = 0.75,
       animate = true,


### PR DESCRIPTION
我使用percent这个属性值为0时饼图不显示，所以我之前改了一下
https://github.com/ant-design/ant-design-pro/pull/2282/commits/c69c1d4118c6d36cef228d52da8504a68acc35ee
我漏改了一处，虽然API文档没提data，但Pie能接受data这个属性而且有人在用了，如果按我之前的改法，那就需要percent不能有默认值，否则不传percent，perconet默认值为0了，后面的逻辑会覆盖掉用户传的data