### PR TITLE
修改getFormItemOptions方法中customprops的错误

### DIFF
--- a/src/components/Login/LoginItem.js
+++ b/src/components/Login/LoginItem.js
@@ -43,9 +43,9 @@ class WarpFormItem extends Component {
     }
   };
 
-  getFormItemOptions = ({ onChange, defaultValue, rules }) => {
+  getFormItemOptions = ({ onChange, defaultValue, customprops, rules }) => {
     const options = {
-      rules: rules || this.customprops.rules,
+      rules: rules || customprops.rules,
     };
     if (onChange) {
       options.onChange = onChange;


### PR DESCRIPTION
this.customprops并不存在，而是通过props传入到组件里的，所以应该是用this.props.customprops获取，而不应该是this.customprops。