### PR TITLE
fix (#2182): top menu layout without submenu display issue

### DIFF
--- a/src/components/SiderMenu/BaseMenu.js
+++ b/src/components/SiderMenu/BaseMenu.js
@@ -179,6 +179,7 @@ export default class BaseMenu extends PureComponent {
         onOpenChange={handleOpenChange}
         selectedKeys={selectedKeys}
         style={style}
+        className={mode === 'horizontal' ? 'top-nav-menu' : ''}
         {...props}
       >
         {this.getNavMenuItems(menuData)}

--- a/src/components/SiderMenu/index.less
+++ b/src/components/SiderMenu/index.less
@@ -63,8 +63,8 @@
 
 :global {
   .top-nav-menu li.ant-menu-item {
-    height: 64px;
-    line-height: 64px;
+    height: @nav-header-height;
+    line-height: @nav-header-height;
   }
   .drawer .drawer-content {
     background: #001529;

--- a/src/components/SiderMenu/index.less
+++ b/src/components/SiderMenu/index.less
@@ -62,6 +62,10 @@
 }
 
 :global {
+  .top-nav-menu li.ant-menu-item {
+    height: 64px;
+    line-height: 64px;
+  }
   .drawer .drawer-content {
     background: #001529;
   }


### PR DESCRIPTION
Fixes #2182 
add a class named 'top-nave-menu' when BaseMenu mode is horizontal to fixed height promblem

Before:
![snip20180920_2](https://user-images.githubusercontent.com/16836801/45805331-14fc0100-bcf1-11e8-8ebb-04d25a5ca002.png)

After:
![snip20180920_3](https://user-images.githubusercontent.com/16836801/45805353-234a1d00-bcf1-11e8-8aa5-072129b6d089.png)

