### PR TITLE
Ellipsis组件和antd的Table组件共用时在Firefox下存在样式问题

### DIFF
--- a/src/components/Ellipsis/index.less
+++ b/src/components/Ellipsis/index.less
@@ -9,7 +9,7 @@
   position: relative;
   .shadow {
     display: block;
-    position: relative;
+    position: absolute;
     color: transparent;
     opacity: 0;
     z-index: -999;


### PR DESCRIPTION
* antd: 3.9.2
* antd-pro: 2.0.0-beta.1
* react: 16.5.0

样式问题出现在Firefox，Chrome没问题。

Firefox下：行高度错误
![image](https://user-images.githubusercontent.com/22495161/46057400-09dd2100-c188-11e8-8e99-463cff6f6623.png)

Chrome下：正常
![image](https://user-images.githubusercontent.com/22495161/46057424-1b262d80-c188-11e8-9bc7-41fdb73fb88a.png)

将`src/components/Ellipsis/index.less`样式文件中`shadow类`下的`position:relative`改为`position:absolute`就没问题了。
