### PR TITLE
Remove redundant title for Tooltip

### DIFF
--- a/src/components/GlobalHeader/RightContent.js
+++ b/src/components/GlobalHeader/RightContent.js
@@ -98,7 +98,6 @@ export default class GlobalHeaderRight extends PureComponent {
             href="https://pro.ant.design/docs/getting-started"
             rel="noopener noreferrer"
             className={styles.action}
-            title="{ formatMessage({id: 'component.globalHeader.help'}) }"
           >
             <Icon type="question-circle-o" />
           </a>


### PR DESCRIPTION
 The **title** prop in `<a />` tag is redundant since `Tooltip` already has one.

What's more, this title prop in `<a />` tag will cause mistake rendering when focus on that tag.
 