### PR TITLE
fix: (#2475, #2445) input box-shadow for login page

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,7 @@ module.exports = {
     'jsx-a11y/click-events-have-key-events': 0,
     'jsx-a11y/no-static-element-interactions': 0,
     'jsx-a11y/anchor-is-valid': 0,
+    'linebreak-style': 0,
   },
   settings: {
     polyfills: ['fetch', 'promises', 'url'],

--- a/src/components/Login/index.less
+++ b/src/components/Login/index.less
@@ -9,7 +9,7 @@
     }
 
     .ant-form-item {
-      margin-bottom: 24px;
+      margin: 0 2px 24px;
     }
   }
 

--- a/src/components/SiderMenu/SiderMenu.js
+++ b/src/components/SiderMenu/SiderMenu.js
@@ -118,7 +118,7 @@ export default class SiderMenu extends PureComponent {
           mode="inline"
           handleOpenChange={this.handleOpenChange}
           onOpenChange={this.handleOpenChange}
-          style={{ padding: '16px 0', width: '100%' }}
+          style={{ padding: '16px 0', width: '100%', overflowX: 'hidden' }}
           {...defaultProps}
         />
       </Sider>


### PR DESCRIPTION
fix #2475 #2445 

> 1. 将主题设为亮色，固定头部和固定侧边栏时，侧边栏出现横向滚动条

