### PR TITLE
style: better analysis page ranking list style

### DIFF
--- a/src/pages/Dashboard/Analysis.js
+++ b/src/pages/Dashboard/Analysis.js
@@ -501,8 +501,16 @@ class Analysis extends Component {
                       <ul className={styles.rankingList}>
                         {this.rankingListData.map((item, i) => (
                           <li key={item.title}>
-                            <span className={i < 3 ? styles.active : ''}>{i + 1}</span>
-                            <span>{item.title}</span>
+                            <span
+                              className={`${styles.rankingItemNumber} ${
+                                i < 3 ? styles.active : ''
+                              }`}
+                            >
+                              {i + 1}
+                            </span>
+                            <span className={styles.rankingItemTitle} title={item.title}>
+                              {item.title}
+                            </span>
                             <span>{numeral(item.total).format('0,0')}</span>
                           </li>
                         ))}


### PR DESCRIPTION
最近在使用`antd-pro`时发现分析页一个排名列表样式好像漏了点什么

这是销售额排名排名：
![image](https://user-images.githubusercontent.com/16172317/46932051-7c9f3500-d080-11e8-8922-2a39fc211d3c.png)

访问量排名：
![image](https://user-images.githubusercontent.com/16172317/46932089-a5272f00-d080-11e8-8392-3610b8dc09e3.png)

不知道是不是原本就是这样设计的，不过既然两个列表从各种方面来说都是并列的，样式统一会不会比较好？

修改后的访问量排名：

![image](https://user-images.githubusercontent.com/16172317/46932177-064f0280-d081-11e8-8fac-83b3ba3f8e16.png)


