### PR TITLE
bugfix: 针对header头部的主题字体颜色，在dark情况下没有发生改变

### DIFF
--- a/src/components/GlobalHeader/RightContent.js
+++ b/src/components/GlobalHeader/RightContent.js
@@ -47,7 +47,7 @@ export default class GlobalHeaderRight extends PureComponent {
       onNoticeVisibleChange,
       onMenuClick,
       onNoticeClear,
-      theme,
+      navTheme,
     } = this.props;
     const menu = (
       <Menu className={styles.menu} selectedKeys={[]} onClick={onMenuClick}>
@@ -72,7 +72,7 @@ export default class GlobalHeaderRight extends PureComponent {
     );
     const noticeData = this.getNoticeData();
     let className = styles.right;
-    if (theme === 'dark') {
+    if (navTheme === 'dark') {
       className = `${styles.right}  ${styles.dark}`;
     }
     return (


### PR DESCRIPTION
在config.js配置中的属性是navTheme  而 RightContent直接使用this.props，没有转换