### PR TITLE
Fixed 404 page error

### DIFF
--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,7 +1,13 @@
 import React from 'react';
 import Link from 'umi/link';
+import { formatMessage } from "umi/locale";
 import Exception from '@/components/Exception';
 
 export default () => (
-  <Exception type="404" style={{ minHeight: 500, height: '100%' }} linkElement={Link} />
+  <Exception
+    type="404"
+    linkElement={Link}
+    desc={formatMessage({id: 'app.exception.description.404'})}
+    backText={formatMessage({id: 'app.exception.back'})}
+  />
 );


### PR DESCRIPTION
When switching locale, the `404` page renders text wrongly.

<img width="1145" alt="404-page-wrong" src="https://user-images.githubusercontent.com/2697870/47013424-ae47f700-d179-11e8-8434-9561f9df5539.png">

The `desc` and `backText` props should be provided to properly respond to different locales.

After modification, it works:

<img width="1048" alt="404-page-ok" src="https://user-images.githubusercontent.com/2697870/47013506-f36c2900-d179-11e8-9b27-58e6b68bddca.png">
