### PR TITLE
Fixed 'menu.form.stepform.stepform' not found in locale error

### DIFF
--- a/config/router.config.js
+++ b/config/router.config.js
@@ -60,7 +60,6 @@ export default [
             routes: [
               {
                 path: '/form/step-form',
-                name: 'stepform',
                 redirect: '/form/step-form/info',
               },
               {


### PR DESCRIPTION
This was caused by extra name in router.config.js.

'/form/step-form' is a pure redirect route and shouldn't have name,
like other redirect routes