### PR TITLE
feat/noticeicon-close[master]

### DIFF
--- a/mock/notices.js
+++ b/mock/notices.js
@@ -43,6 +43,7 @@ const getNotices = (req, res) =>
       description: '描述信息描述信息描述信息',
       datetime: '2017-08-07',
       type: 'message',
+      clickClose: true,
     },
     {
       id: '000000007',
@@ -51,6 +52,7 @@ const getNotices = (req, res) =>
       description: '这种模板用于提醒谁与你发生了互动，左侧放『谁』的头像',
       datetime: '2017-08-07',
       type: 'message',
+      clickClose: true,
     },
     {
       id: '000000008',
@@ -59,6 +61,7 @@ const getNotices = (req, res) =>
       description: '这种模板用于提醒谁与你发生了互动，左侧放『谁』的头像',
       datetime: '2017-08-07',
       type: 'message',
+      clickClose: true,
     },
     {
       id: '000000009',

--- a/src/components/GlobalHeader/RightContent.js
+++ b/src/components/GlobalHeader/RightContent.js
@@ -116,6 +116,7 @@ export default class GlobalHeaderRight extends PureComponent {
           onPopupVisibleChange={onNoticeVisibleChange}
           loading={fetchingNotices}
           popupAlign={{ offset: [20, -16] }}
+          clearClose
         >
           <NoticeIcon.Tab
             list={noticeData.notification}

--- a/src/components/NoticeIcon/demo/popover.md
+++ b/src/components/NoticeIcon/demo/popover.md
@@ -49,6 +49,7 @@ const data = [{
   description: '描述信息描述信息描述信息',
   datetime: '2017-08-07',
   type: '消息',
+  clickClose: true,
 }, {
   id: '000000007',
   avatar: 'https://gw.alipayobjects.com/zos/rmsportal/fcHMVNCjPOsbUGdEduuv.jpeg',
@@ -56,6 +57,7 @@ const data = [{
   description: '这种模板用于提醒谁与你发生了互动，左侧放『谁』的头像',
   datetime: '2017-08-07',
   type: '消息',
+  clickClose: true,
 }, {
   id: '000000008',
   avatar: 'https://gw.alipayobjects.com/zos/rmsportal/fcHMVNCjPOsbUGdEduuv.jpeg',
@@ -63,6 +65,7 @@ const data = [{
   description: '这种模板用于提醒谁与你发生了互动，左侧放『谁』的头像',
   datetime: '2017-08-07',
   type: '消息',
+  clickClose: true,
 }, {
   id: '000000009',
   title: '任务名称',

--- a/src/components/NoticeIcon/index.d.ts
+++ b/src/components/NoticeIcon/index.d.ts
@@ -22,6 +22,7 @@ export interface INoticeIconProps {
   onPopupVisibleChange?: (visible: boolean) => void;
   popupVisible?: boolean;
   locale?: { emptyText: string; clear: string };
+  clearClose?: boolean;
 }
 
 export default class NoticeIcon extends React.Component<INoticeIconProps, any> {

--- a/src/components/NoticeIcon/index.js
+++ b/src/components/NoticeIcon/index.js
@@ -107,8 +107,7 @@ export default class NoticeIcon extends PureComponent {
         popupAlign={popupAlign}
         onVisibleChange={onPopupVisibleChange}
         {...popoverProps}
-         /* eslint-disable */ 
-        ref={node => { this.popover = ReactDOM.findDOMNode(node)}}
+        ref={node => { this.popover = ReactDOM.findDOMNode(node)}} // eslint-disable-line
       >
         {trigger}
       </Popover>

--- a/src/components/NoticeIcon/index.js
+++ b/src/components/NoticeIcon/index.js
@@ -1,4 +1,5 @@
 import React, { PureComponent } from 'react';
+import ReactDOM from 'react-dom';
 import { Popover, Icon, Tabs, Badge, Spin } from 'antd';
 import classNames from 'classnames';
 import List from './NoticeList';
@@ -15,6 +16,7 @@ export default class NoticeIcon extends PureComponent {
     onTabChange: () => {},
     onClear: () => {},
     loading: false,
+    clearClose: false,
     locale: {
       emptyText: 'No notifications',
       clear: 'Clear',
@@ -24,8 +26,20 @@ export default class NoticeIcon extends PureComponent {
 
   onItemClick = (item, tabProps) => {
     const { onItemClick } = this.props;
+    const { clickClose } = item;
     onItemClick(item, tabProps);
+    if (clickClose) {
+      this.popover.click();
+    }
   };
+
+  onClear = (name) => {
+    const { onClear, clearClose } = this.props;
+    onClear(name)
+    if (clearClose) {
+      this.popover.click();
+    }
+  }
 
   onTabChange = tabType => {
     const { onTabChange } = this.props;
@@ -33,7 +47,7 @@ export default class NoticeIcon extends PureComponent {
   };
 
   getNotificationBox() {
-    const { children, loading, locale, onClear } = this.props;
+    const { children, loading, locale } = this.props;
     if (!children) {
       return null;
     }
@@ -48,7 +62,7 @@ export default class NoticeIcon extends PureComponent {
             {...child.props}
             data={child.props.list}
             onClick={item => this.onItemClick(item, child.props)}
-            onClear={() => onClear(child.props.name)}
+            onClear={() => this.onClear(child.props.name)}
             title={child.props.title}
             locale={locale}
           />
@@ -93,6 +107,8 @@ export default class NoticeIcon extends PureComponent {
         popupAlign={popupAlign}
         onVisibleChange={onPopupVisibleChange}
         {...popoverProps}
+         /* eslint-disable */ 
+        ref={node => { this.popover = ReactDOM.findDOMNode(node)}}
       >
         {trigger}
       </Popover>


### PR DESCRIPTION
# 功能 Feature

实现了点击列表项目后关闭弹窗，以及点击清除按钮后关闭弹窗的功能。
Click the list item after closing the pop-up, and click the clear button to close the pop-up.

# 更改 Change

增加了两个新的属性，一个在 `NoticeIcon` 组件上，另一个是在 `NoticeIcon.Tab` 中` list` 的元素对象上。
Two new properties have been added, one on the NoticeIcon component and the other on the element object of the list in NoticeIcon.Tab.

# 使用 Usage

增加清除关闭的属性 `clearClose` 到 `NoticeIcon` 上. 
Add `clearClose` property to `NoticeIcon`.

```js
<NoticeIcon
    className={styles.action}
    count={currentUser.notifyCount}
    onItemClick={(item, tabProps) => {
        console.log(item, tabProps); // eslint-disable-line
    }}
    locale={{
        emptyText: formatMessage({ id: 'component.noticeIcon.empty' }),
        clear: formatMessage({ id: 'component.noticeIcon.clear' }),
    }}
    onClear={onNoticeClear}
    onPopupVisibleChange={onNoticeVisibleChange}
    loading={fetchingNotices}
    popupAlign={{ offset: [20, -16] }}
    clearClose // new property
>
    ...
</NoticeIcon>
```

增加 `NoticeIcon.Tab` 中 `list` 的元素对象属性: `clickClose`
Add a property to the element object properties of `list` in `NoticeIcon.Tab`: `clickClose`

```js
{
    id: '000000006',
    avatar: 'https: //gw.alipayobjects.com/zos/rmsportal/fcHMVNCjPOsbUGdEduuv.jpeg',
    title: '曲丽丽 评论了你',
    description: '描述信息描述信息描述信息',
    datetime: '2017-08-07',
    type: 'message',
    clickClose: true, // new property
},
{
    id: '000000007',
    avatar: 'https: //gw.alipayobjects.com/zos/rmsportal/fcHMVNCjPOsbUGdEduuv.jpeg',
    title: '朱偏右 回复了你',
    description: '这种模板用于提醒谁与你发生了互动，左侧放『谁』的头像',
    datetime: '2017-08-07',
    type: 'message',
    clickClose: true, // new property
},
```

# Issue

#2690 

# 修正 update

合并到主分支
merge to the master branch