### PR TITLE
BasicLayout 优化建议 #2665

### DIFF
--- a/src/components/GlobalHeader/RightContent.js
+++ b/src/components/GlobalHeader/RightContent.js
@@ -38,7 +38,7 @@ export default class GlobalHeaderRight extends PureComponent {
       return newNotice;
     });
     const dataMap = groupBy(newNotices, 'type');
-    return dataMap
+    return dataMap;
   }
 
   /**

--- a/src/components/GlobalHeader/RightContent.js
+++ b/src/components/GlobalHeader/RightContent.js
@@ -37,7 +37,8 @@ export default class GlobalHeaderRight extends PureComponent {
       }
       return newNotice;
     });
-    return groupBy(newNotices, 'type');
+    const dataMap = groupBy(newNotices, 'type');
+    return dataMap
   }
 
   /**
@@ -124,7 +125,6 @@ export default class GlobalHeaderRight extends PureComponent {
     if (theme === 'dark') {
       className = `${styles.right}  ${styles.dark}`;
     }
-
     return (
       <div className={className}>
         <HeaderSearch

--- a/src/components/GlobalHeader/RightContent.js
+++ b/src/components/GlobalHeader/RightContent.js
@@ -43,33 +43,32 @@ export default class GlobalHeaderRight extends PureComponent {
   /**
    * 支持外部定义搜索事件响应
    */
-  onSearch = (value)=>{
-    const {onSearch} = this.props
-    if(onSearch){
-      onSearch(value)
+  onSearch = value => {
+    const { onSearch } = this.props;
+    if (onSearch) {
+      onSearch(value);
     }
+  };
 
-  }
-
-   /**
+  /**
    * 支持外部定义回车事件响应
    */
-  onPressEnter = (value)=>{
-    const {onSearch} = this.props
-    if(onSearch){
-      onSearch(value)
+  onPressEnter = value => {
+    const { onSearch } = this.props;
+    if (onSearch) {
+      onSearch(value);
     }
-  }
+  };
 
   /**
    * 支持外部定义通知记录点击事件
    */
-  onItemClick = (item,tabProps)=>{
-    const {onItemClick} = this.props
-    if(onItemClick){
-      onItemClick(item,tabProps)
+  onItemClick = (item, tabProps) => {
+    const { onItemClick } = this.props;
+    if (onItemClick) {
+      onItemClick(item, tabProps);
     }
-  }
+  };
 
   render() {
     const {
@@ -80,8 +79,8 @@ export default class GlobalHeaderRight extends PureComponent {
       onNoticeClear,
       notifyCount,
       theme,
-      searchDataSource=[],
-      notificationType="notification,message,event",
+      searchDataSource = [],
+      notificationType = 'notification,message,event',
     } = this.props;
     const menu = (
       <Menu className={styles.menu} selectedKeys={[]} onClick={onMenuClick}>
@@ -141,36 +140,40 @@ export default class GlobalHeaderRight extends PureComponent {
           loading={fetchingNotices}
           popupAlign={{ offset: [20, -16] }}
         >
-          {notificationType.indexOf('notification') !== -1? // 支持自定义显示消息标签页
-            (<NoticeIcon.Tab
+          {notificationType.indexOf('notification') !== -1 ? ( // 支持自定义显示消息标签页
+            <NoticeIcon.Tab
               list={noticeData.notification}
               title={formatMessage({ id: 'component.globalHeader.notification' })}
               name="notification"
               emptyText={formatMessage({ id: 'component.globalHeader.notification.empty' })}
               emptyImage="https://gw.alipayobjects.com/zos/rmsportal/wAhyIChODzsoKIOBHcBk.svg"
-            />):''
-           }
-          
-          {notificationType.indexOf('message') !== -1?
-            (<NoticeIcon.Tab
+            />
+          ) : (
+            ''
+          )}
+
+          {notificationType.indexOf('message') !== -1 ? (
+            <NoticeIcon.Tab
               list={noticeData.message}
               title={formatMessage({ id: 'component.globalHeader.message' })}
               name="message"
               emptyText={formatMessage({ id: 'component.globalHeader.message.empty' })}
               emptyImage="https://gw.alipayobjects.com/zos/rmsportal/sAuJeJzSKbUmHfBQRzmZ.svg"
-            />)
-            :'' 
-          }
-          {notificationType.indexOf('event') !== -1?
-              (<NoticeIcon.Tab
-                list={noticeData.event}
-                title={formatMessage({ id: 'component.globalHeader.event' })}
-                name="event"
-                emptyText={formatMessage({ id: 'component.globalHeader.event.empty' })}
-                emptyImage="https://gw.alipayobjects.com/zos/rmsportal/HsIsxMZiWKrNUavQUXqx.svg"
-              />)
-              :'' 
-            }
+            />
+          ) : (
+            ''
+          )}
+          {notificationType.indexOf('event') !== -1 ? (
+            <NoticeIcon.Tab
+              list={noticeData.event}
+              title={formatMessage({ id: 'component.globalHeader.event' })}
+              name="event"
+              emptyText={formatMessage({ id: 'component.globalHeader.event.empty' })}
+              emptyImage="https://gw.alipayobjects.com/zos/rmsportal/HsIsxMZiWKrNUavQUXqx.svg"
+            />
+          ) : (
+            ''
+          )}
         </NoticeIcon>
         {currentUser.name ? (
           <Dropdown overlay={menu}>

--- a/src/components/GlobalHeader/RightContent.js
+++ b/src/components/GlobalHeader/RightContent.js
@@ -40,6 +40,37 @@ export default class GlobalHeaderRight extends PureComponent {
     return groupBy(newNotices, 'type');
   }
 
+  /**
+   * 支持外部定义搜索事件响应
+   */
+  onSearch = (value)=>{
+    const {onSearch} = this.props
+    if(onSearch){
+      onSearch(value)
+    }
+
+  }
+
+   /**
+   * 支持外部定义回车事件响应
+   */
+  onPressEnter = (value)=>{
+    const {onSearch} = this.props
+    if(onSearch){
+      onSearch(value)
+    }
+  }
+
+  /**
+   * 支持外部定义通知记录点击事件
+   */
+  onItemClick = (item,tabProps)=>{
+    const {onItemClick} = this.props
+    if(onItemClick){
+      onItemClick(item,tabProps)
+    }
+  }
+
   render() {
     const {
       currentUser,
@@ -47,7 +78,10 @@ export default class GlobalHeaderRight extends PureComponent {
       onNoticeVisibleChange,
       onMenuClick,
       onNoticeClear,
+      notifyCount,
       theme,
+      searchDataSource=[],
+      notificationType="notification,message,event",
     } = this.props;
     const menu = (
       <Menu className={styles.menu} selectedKeys={[]} onClick={onMenuClick}>
@@ -80,17 +114,9 @@ export default class GlobalHeaderRight extends PureComponent {
         <HeaderSearch
           className={`${styles.action} ${styles.search}`}
           placeholder={formatMessage({ id: 'component.globalHeader.search' })}
-          dataSource={[
-            formatMessage({ id: 'component.globalHeader.search.example1' }),
-            formatMessage({ id: 'component.globalHeader.search.example2' }),
-            formatMessage({ id: 'component.globalHeader.search.example3' }),
-          ]}
-          onSearch={value => {
-            console.log('input', value); // eslint-disable-line
-          }}
-          onPressEnter={value => {
-            console.log('enter', value); // eslint-disable-line
-          }}
+          dataSource={searchDataSource}
+          onSearch={this.search}
+          onPressEnter={this.onPressEnter}
         />
         <Tooltip title={formatMessage({ id: 'component.globalHeader.help' })}>
           <a
@@ -104,10 +130,8 @@ export default class GlobalHeaderRight extends PureComponent {
         </Tooltip>
         <NoticeIcon
           className={styles.action}
-          count={currentUser.notifyCount}
-          onItemClick={(item, tabProps) => {
-            console.log(item, tabProps); // eslint-disable-line
-          }}
+          count={notifyCount || currentUser.notifyCount}
+          onItemClick={this.onItemClick}
           locale={{
             emptyText: formatMessage({ id: 'component.noticeIcon.empty' }),
             clear: formatMessage({ id: 'component.noticeIcon.clear' }),
@@ -117,27 +141,36 @@ export default class GlobalHeaderRight extends PureComponent {
           loading={fetchingNotices}
           popupAlign={{ offset: [20, -16] }}
         >
-          <NoticeIcon.Tab
-            list={noticeData.notification}
-            title={formatMessage({ id: 'component.globalHeader.notification' })}
-            name="notification"
-            emptyText={formatMessage({ id: 'component.globalHeader.notification.empty' })}
-            emptyImage="https://gw.alipayobjects.com/zos/rmsportal/wAhyIChODzsoKIOBHcBk.svg"
-          />
-          <NoticeIcon.Tab
-            list={noticeData.message}
-            title={formatMessage({ id: 'component.globalHeader.message' })}
-            name="message"
-            emptyText={formatMessage({ id: 'component.globalHeader.message.empty' })}
-            emptyImage="https://gw.alipayobjects.com/zos/rmsportal/sAuJeJzSKbUmHfBQRzmZ.svg"
-          />
-          <NoticeIcon.Tab
-            list={noticeData.event}
-            title={formatMessage({ id: 'component.globalHeader.event' })}
-            name="event"
-            emptyText={formatMessage({ id: 'component.globalHeader.event.empty' })}
-            emptyImage="https://gw.alipayobjects.com/zos/rmsportal/HsIsxMZiWKrNUavQUXqx.svg"
-          />
+          {notificationType.indexOf('notification') !== -1? // 支持自定义显示消息标签页
+            (<NoticeIcon.Tab
+              list={noticeData.notification}
+              title={formatMessage({ id: 'component.globalHeader.notification' })}
+              name="notification"
+              emptyText={formatMessage({ id: 'component.globalHeader.notification.empty' })}
+              emptyImage="https://gw.alipayobjects.com/zos/rmsportal/wAhyIChODzsoKIOBHcBk.svg"
+            />):''
+           }
+          
+          {notificationType.indexOf('message') !== -1?
+            (<NoticeIcon.Tab
+              list={noticeData.message}
+              title={formatMessage({ id: 'component.globalHeader.message' })}
+              name="message"
+              emptyText={formatMessage({ id: 'component.globalHeader.message.empty' })}
+              emptyImage="https://gw.alipayobjects.com/zos/rmsportal/sAuJeJzSKbUmHfBQRzmZ.svg"
+            />)
+            :'' 
+          }
+          {notificationType.indexOf('event') !== -1?
+              (<NoticeIcon.Tab
+                list={noticeData.event}
+                title={formatMessage({ id: 'component.globalHeader.event' })}
+                name="event"
+                emptyText={formatMessage({ id: 'component.globalHeader.event.empty' })}
+                emptyImage="https://gw.alipayobjects.com/zos/rmsportal/HsIsxMZiWKrNUavQUXqx.svg"
+              />)
+              :'' 
+            }
         </NoticeIcon>
         {currentUser.name ? (
           <Dropdown overlay={menu}>

--- a/src/components/GlobalHeader/RightContent.js
+++ b/src/components/GlobalHeader/RightContent.js
@@ -80,7 +80,7 @@ export default class GlobalHeaderRight extends PureComponent {
       notifyCount,
       theme,
       searchDataSource = [],
-      notificationType = 'notification,message,event',
+      notificationTypes = ['notification', 'message', 'event'],
     } = this.props;
     const menu = (
       <Menu className={styles.menu} selectedKeys={[]} onClick={onMenuClick}>
@@ -140,40 +140,18 @@ export default class GlobalHeaderRight extends PureComponent {
           loading={fetchingNotices}
           popupAlign={{ offset: [20, -16] }}
         >
-          {notificationType.indexOf('notification') !== -1 ? ( // 支持自定义显示消息标签页
+          {notificationTypes.map(item => (
             <NoticeIcon.Tab
-              list={noticeData.notification}
-              title={formatMessage({ id: 'component.globalHeader.notification' })}
-              name="notification"
-              emptyText={formatMessage({ id: 'component.globalHeader.notification.empty' })}
-              emptyImage="https://gw.alipayobjects.com/zos/rmsportal/wAhyIChODzsoKIOBHcBk.svg"
+              key={item}
+              list={noticeData[`${item}`]}
+              title={formatMessage({ id: `component.globalHeader.${item}` })}
+              name={`${item}`}
+              emptyText={formatMessage({ id: `component.globalHeader.${item}.empty` })}
+              emptyImage={`https://gw.alipayobjects.com/zos/rmsportal/${
+                item === 'message' ? 'sAuJeJzSKbUmHfBQRzmZ' : 'wAhyIChODzsoKIOBHcBk'
+              }.svg`}
             />
-          ) : (
-            ''
-          )}
-
-          {notificationType.indexOf('message') !== -1 ? (
-            <NoticeIcon.Tab
-              list={noticeData.message}
-              title={formatMessage({ id: 'component.globalHeader.message' })}
-              name="message"
-              emptyText={formatMessage({ id: 'component.globalHeader.message.empty' })}
-              emptyImage="https://gw.alipayobjects.com/zos/rmsportal/sAuJeJzSKbUmHfBQRzmZ.svg"
-            />
-          ) : (
-            ''
-          )}
-          {notificationType.indexOf('event') !== -1 ? (
-            <NoticeIcon.Tab
-              list={noticeData.event}
-              title={formatMessage({ id: 'component.globalHeader.event' })}
-              name="event"
-              emptyText={formatMessage({ id: 'component.globalHeader.event.empty' })}
-              emptyImage="https://gw.alipayobjects.com/zos/rmsportal/HsIsxMZiWKrNUavQUXqx.svg"
-            />
-          ) : (
-            ''
-          )}
+          ))}
         </NoticeIcon>
         {currentUser.name ? (
           <Dropdown overlay={menu}>

--- a/src/components/GlobalHeader/RightContent.js
+++ b/src/components/GlobalHeader/RightContent.js
@@ -70,8 +70,8 @@ export default class GlobalHeaderRight extends PureComponent {
     }
   };
 
-  noticeIconTabs = () =>{
-    const { notificationTypes = ['notification', 'message', 'event']} = this.props;
+  noticeIconTabs = () => {
+    const { notificationTypes = ['notification', 'message', 'event'] } = this.props;
     const noticeData = this.getNoticeData();
     const tabs = notificationTypes.map(item => (
       <NoticeIcon.Tab
@@ -84,9 +84,9 @@ export default class GlobalHeaderRight extends PureComponent {
           item === 'message' ? 'sAuJeJzSKbUmHfBQRzmZ' : 'wAhyIChODzsoKIOBHcBk'
         }.svg`}
       />
-    ))
-    return tabs 
-  }
+    ));
+    return tabs;
+  };
 
   render() {
     const {

--- a/src/components/GlobalHeader/RightContent.js
+++ b/src/components/GlobalHeader/RightContent.js
@@ -70,6 +70,24 @@ export default class GlobalHeaderRight extends PureComponent {
     }
   };
 
+  noticeIconTabs = () =>{
+    const { notificationTypes = ['notification', 'message', 'event']} = this.props;
+    const noticeData = this.getNoticeData();
+    const tabs = notificationTypes.map(item => (
+      <NoticeIcon.Tab
+        key={item}
+        list={noticeData[`${item}`]}
+        title={formatMessage({ id: `component.globalHeader.${item}` })}
+        name={`${item}`}
+        emptyText={formatMessage({ id: `component.globalHeader.${item}.empty` })}
+        emptyImage={`https://gw.alipayobjects.com/zos/rmsportal/${
+          item === 'message' ? 'sAuJeJzSKbUmHfBQRzmZ' : 'wAhyIChODzsoKIOBHcBk'
+        }.svg`}
+      />
+    ))
+    return tabs 
+  }
+
   render() {
     const {
       currentUser,
@@ -80,7 +98,6 @@ export default class GlobalHeaderRight extends PureComponent {
       notifyCount,
       theme,
       searchDataSource = [],
-      notificationTypes = ['notification', 'message', 'event'],
     } = this.props;
     const menu = (
       <Menu className={styles.menu} selectedKeys={[]} onClick={onMenuClick}>
@@ -103,11 +120,11 @@ export default class GlobalHeaderRight extends PureComponent {
         </Menu.Item>
       </Menu>
     );
-    const noticeData = this.getNoticeData();
     let className = styles.right;
     if (theme === 'dark') {
       className = `${styles.right}  ${styles.dark}`;
     }
+
     return (
       <div className={className}>
         <HeaderSearch
@@ -140,18 +157,7 @@ export default class GlobalHeaderRight extends PureComponent {
           loading={fetchingNotices}
           popupAlign={{ offset: [20, -16] }}
         >
-          {notificationTypes.map(item => (
-            <NoticeIcon.Tab
-              key={item}
-              list={noticeData[`${item}`]}
-              title={formatMessage({ id: `component.globalHeader.${item}` })}
-              name={`${item}`}
-              emptyText={formatMessage({ id: `component.globalHeader.${item}.empty` })}
-              emptyImage={`https://gw.alipayobjects.com/zos/rmsportal/${
-                item === 'message' ? 'sAuJeJzSKbUmHfBQRzmZ' : 'wAhyIChODzsoKIOBHcBk'
-              }.svg`}
-            />
-          ))}
+          {this.noticeIconTabs()}
         </NoticeIcon>
         {currentUser.name ? (
           <Dropdown overlay={menu}>

--- a/src/components/GlobalHeader/index.js
+++ b/src/components/GlobalHeader/index.js
@@ -23,7 +23,7 @@ export default class GlobalHeader extends PureComponent {
     this.triggerResizeEvent();
   };
   render() {
-    const { collapsed, isMobile, logo } = this.props;
+    const { collapsed, isMobile, logo,notices } = this.props;
     return (
       <div className={styles.header}>
         {isMobile && (

--- a/src/components/GlobalHeader/index.js
+++ b/src/components/GlobalHeader/index.js
@@ -23,7 +23,7 @@ export default class GlobalHeader extends PureComponent {
     this.triggerResizeEvent();
   };
   render() {
-    const { collapsed, isMobile, logo,notices } = this.props;
+    const { collapsed, isMobile, logo, notices } = this.props;
     return (
       <div className={styles.header}>
         {isMobile && (

--- a/src/layouts/BasicLayout.js
+++ b/src/layouts/BasicLayout.js
@@ -306,10 +306,10 @@ class BasicLayout extends React.PureComponent {
  *  onPressEnter, // 顶部搜索回车事件回调函数 function(value:string)
  *  searchDataSource, // 顶部搜索提示数据 string[]
  *  onItemClick,  // 消息记录点击事件回调行数 function(item:obect,tabprops:object)
- *  notificationType="notification,message,event", // 消息类型展示自定义
+ *  notificationTypes=['notification','message','event'], // 消息类型展示自定义
  *  notifyCount, // 总消息条数 value:number
  *  fetchingNotices, // 消息面板显示时,加载图标状态显示控制
- *  handleNoticeVisibleChange,  // 消息面板展开事件 function(type:String)
+ *  handleNoticeVisibleChange,  // 消息面板展开事件 function(visible:boolean)
  *  menuData, // 菜单数据 ，结构参考formatter object[]
  *  pageTitle, // 页面title
  * }
@@ -319,5 +319,6 @@ export default connect(({ global, setting, loading }) => ({
   layout: setting.layout,
   loading,
   // pageTitle:'demo',
+  notificationTypes: ['notification', 'message'],
   ...setting,
 }))(BasicLayout);

--- a/src/layouts/BasicLayout.js
+++ b/src/layouts/BasicLayout.js
@@ -141,11 +141,15 @@ class BasicLayout extends React.PureComponent {
     };
   }
 
+  /**
+   * 支持外部定义MenuData
+   */
   getMenuData() {
     const {
       route: { routes },
+      menuData,
     } = this.props;
-    return memoizeOneFormatter(routes);
+    return menuData || memoizeOneFormatter(routes);
   }
 
   /**
@@ -175,16 +179,18 @@ class BasicLayout extends React.PureComponent {
   };
 
   getPageTitle = pathname => {
+    const { pageTitle } = this.props
     const currRouterData = this.matchParamsPath(pathname);
-
+    // 支持自定义页面title
+    const title =  pageTitle || 'Ant Design Pro';
     if (!currRouterData) {
-      return 'Ant Design Pro';
+      return title;
     }
     const message = formatMessage({
       id: currRouterData.locale || currRouterData.name,
       defaultMessage: currRouterData.name,
     });
-    return `${message} - Ant Design Pro`;
+    return `${message} - ${title}`;
   };
 
   getLayoutStyle = () => {
@@ -230,10 +236,14 @@ class BasicLayout extends React.PureComponent {
       layout: PropsLayout,
       children,
       location: { pathname },
+      loading,
+      fetchingNotices,
     } = this.props;
     const { isMobile, menuData } = this.state;
     const isTop = PropsLayout === 'topmenu';
     const routerConfig = this.matchParamsPath(pathname);
+    const fetching = fetchingNotices || loading.effects['global/fetchNotices'];
+    const headerProps = {...this.props,fetchingNotices:fetching}
     const layout = (
       <Layout>
         {isTop && !isMobile ? null : (
@@ -258,7 +268,8 @@ class BasicLayout extends React.PureComponent {
             handleMenuCollapse={this.handleMenuCollapse}
             logo={logo}
             isMobile={isMobile}
-            {...this.props}
+            {...headerProps}
+            
           />
           <Content style={this.getContentStyle()}>
             <Authorized
@@ -288,9 +299,26 @@ class BasicLayout extends React.PureComponent {
     );
   }
 }
-
-export default connect(({ global, setting }) => ({
+/**
+  * 如果您想要扩展 BasicLayout ，同时又想通过更新ant-design-pro来获得antd-pro团队最新特性，可以通过包装BasicLayout实现
+  * 以下是BasicLayout 外部可定义props
+  * props = {
+  *  onSearch, // 顶部搜索回调函数 function(value:string)
+  *  onPressEnter, // 顶部搜索回车事件回调函数 function(value:string)
+  *  searchDataSource, // 顶部搜索提示数据 string[]
+  *  onItemClick,  // 消息记录点击事件回调行数 function(item:obect,tabprops:object)
+  *  notificationType="notification,message,event", // 消息类型展示自定义
+  *  notifyCount, // 总消息条数 value:number
+  *  fetchingNotices, // 消息面板显示时,加载图标状态显示控制
+  *  handleNoticeVisibleChange,  // 消息面板展开事件 function(type:String)
+  *  menuData, // 菜单数据 ，结构参考formatter object[]
+  *  pageTitle, // 页面title
+  * }
+  */
+export default connect(({ global, setting,loading }) => ({
   collapsed: global.collapsed,
   layout: setting.layout,
+  loading,
+  // pageTitle:'demo',
   ...setting,
 }))(BasicLayout);

--- a/src/layouts/BasicLayout.js
+++ b/src/layouts/BasicLayout.js
@@ -310,7 +310,7 @@ class BasicLayout extends React.PureComponent {
  *  notifyCount, // 总消息条数 value:number
  *  fetchingNotices, // 消息面板显示时,加载图标状态显示控制
  *  handleNoticeVisibleChange,  // 消息面板展开事件 function(visible:boolean)
- *  menuData, // 菜单数据 ，object[],结构参考formatter 
+ *  menuData, // 菜单数据 ，object[],结构参考formatter
  *  pageTitle, // 页面title
  * }
  */
@@ -318,7 +318,7 @@ export default connect(({ global, setting, loading }) => ({
   collapsed: global.collapsed,
   layout: setting.layout,
   loading,
-  pageTitle:'demo',
+  pageTitle: 'demo',
   notificationTypes: ['notification', 'message'],
   ...setting,
 }))(BasicLayout);

--- a/src/layouts/BasicLayout.js
+++ b/src/layouts/BasicLayout.js
@@ -305,20 +305,20 @@ class BasicLayout extends React.PureComponent {
  *  onSearch, // 顶部搜索回调函数 function(value:string)
  *  onPressEnter, // 顶部搜索回车事件回调函数 function(value:string)
  *  searchDataSource, // 顶部搜索提示数据 string[]
- *  onItemClick,  // 消息记录点击事件回调行数 function(item:obect,tabprops:object)
+ *  onItemClick,  // 消息记录点击事件回调函数 function(item:obect,tabprops:object)
  *  notificationTypes=['notification','message','event'], // 消息类型展示自定义
  *  notifyCount, // 总消息条数 value:number
+ *  handleNoticeClear(type),// 清理消息回调函数
  *  fetchingNotices, // 消息面板显示时,加载图标状态显示控制
  *  handleNoticeVisibleChange,  // 消息面板展开事件 function(visible:boolean)
  *  menuData, // 菜单数据 ，object[],结构参考formatter
  *  pageTitle, // 页面title
  * }
  */
-export default connect(({ global, setting, loading }) => ({
+export default connect(({ global, setting,loading }) => ({
   collapsed: global.collapsed,
   layout: setting.layout,
-  loading,
   pageTitle: 'demo',
-  notificationTypes: ['notification', 'message'],
+  loading,
   ...setting,
 }))(BasicLayout);

--- a/src/layouts/BasicLayout.js
+++ b/src/layouts/BasicLayout.js
@@ -315,7 +315,7 @@ class BasicLayout extends React.PureComponent {
  *  pageTitle, // 页面title
  * }
  */
-export default connect(({ global, setting,loading }) => ({
+export default connect(({ global, setting, loading }) => ({
   collapsed: global.collapsed,
   layout: setting.layout,
   pageTitle: 'demo',

--- a/src/layouts/BasicLayout.js
+++ b/src/layouts/BasicLayout.js
@@ -179,10 +179,10 @@ class BasicLayout extends React.PureComponent {
   };
 
   getPageTitle = pathname => {
-    const { pageTitle } = this.props
+    const { pageTitle } = this.props;
     const currRouterData = this.matchParamsPath(pathname);
     // 支持自定义页面title
-    const title =  pageTitle || 'Ant Design Pro';
+    const title = pageTitle || 'Ant Design Pro';
     if (!currRouterData) {
       return title;
     }
@@ -243,7 +243,7 @@ class BasicLayout extends React.PureComponent {
     const isTop = PropsLayout === 'topmenu';
     const routerConfig = this.matchParamsPath(pathname);
     const fetching = fetchingNotices || loading.effects['global/fetchNotices'];
-    const headerProps = {...this.props,fetchingNotices:fetching}
+    const headerProps = { ...this.props, fetchingNotices: fetching };
     const layout = (
       <Layout>
         {isTop && !isMobile ? null : (
@@ -269,7 +269,6 @@ class BasicLayout extends React.PureComponent {
             logo={logo}
             isMobile={isMobile}
             {...headerProps}
-            
           />
           <Content style={this.getContentStyle()}>
             <Authorized
@@ -300,22 +299,22 @@ class BasicLayout extends React.PureComponent {
   }
 }
 /**
-  * 如果您想要扩展 BasicLayout ，同时又想通过更新ant-design-pro来获得antd-pro团队最新特性，可以通过包装BasicLayout实现
-  * 以下是BasicLayout 外部可定义props
-  * props = {
-  *  onSearch, // 顶部搜索回调函数 function(value:string)
-  *  onPressEnter, // 顶部搜索回车事件回调函数 function(value:string)
-  *  searchDataSource, // 顶部搜索提示数据 string[]
-  *  onItemClick,  // 消息记录点击事件回调行数 function(item:obect,tabprops:object)
-  *  notificationType="notification,message,event", // 消息类型展示自定义
-  *  notifyCount, // 总消息条数 value:number
-  *  fetchingNotices, // 消息面板显示时,加载图标状态显示控制
-  *  handleNoticeVisibleChange,  // 消息面板展开事件 function(type:String)
-  *  menuData, // 菜单数据 ，结构参考formatter object[]
-  *  pageTitle, // 页面title
-  * }
-  */
-export default connect(({ global, setting,loading }) => ({
+ * 如果您想要扩展 BasicLayout ，同时又想通过更新ant-design-pro来获得antd-pro团队最新特性，可以通过包装BasicLayout实现
+ * 以下是BasicLayout 外部可定义props
+ * props = {
+ *  onSearch, // 顶部搜索回调函数 function(value:string)
+ *  onPressEnter, // 顶部搜索回车事件回调函数 function(value:string)
+ *  searchDataSource, // 顶部搜索提示数据 string[]
+ *  onItemClick,  // 消息记录点击事件回调行数 function(item:obect,tabprops:object)
+ *  notificationType="notification,message,event", // 消息类型展示自定义
+ *  notifyCount, // 总消息条数 value:number
+ *  fetchingNotices, // 消息面板显示时,加载图标状态显示控制
+ *  handleNoticeVisibleChange,  // 消息面板展开事件 function(type:String)
+ *  menuData, // 菜单数据 ，结构参考formatter object[]
+ *  pageTitle, // 页面title
+ * }
+ */
+export default connect(({ global, setting, loading }) => ({
   collapsed: global.collapsed,
   layout: setting.layout,
   loading,

--- a/src/layouts/BasicLayout.js
+++ b/src/layouts/BasicLayout.js
@@ -310,7 +310,7 @@ class BasicLayout extends React.PureComponent {
  *  notifyCount, // 总消息条数 value:number
  *  fetchingNotices, // 消息面板显示时,加载图标状态显示控制
  *  handleNoticeVisibleChange,  // 消息面板展开事件 function(visible:boolean)
- *  menuData, // 菜单数据 ，结构参考formatter object[]
+ *  menuData, // 菜单数据 ，object[],结构参考formatter 
  *  pageTitle, // 页面title
  * }
  */
@@ -318,7 +318,7 @@ export default connect(({ global, setting, loading }) => ({
   collapsed: global.collapsed,
   layout: setting.layout,
   loading,
-  // pageTitle:'demo',
+  pageTitle:'demo',
   notificationTypes: ['notification', 'message'],
   ...setting,
 }))(BasicLayout);

--- a/src/layouts/Header.js
+++ b/src/layouts/Header.js
@@ -42,7 +42,7 @@ class HeaderView extends PureComponent {
     return collapsed ? 'calc(100% - 80px)' : 'calc(100% - 256px)';
   };
 
-  handleNoticeClear = type => {
+  handleNoticeClear1 = type => {
     const { handleNoticeClear } = this.props;
     // 支持自定义
     if (handleNoticeClear) {
@@ -142,7 +142,7 @@ class HeaderView extends PureComponent {
             mode="horizontal"
             Authorized={Authorized}
             onCollapse={handleMenuCollapse}
-            onNoticeClear={this.handleNoticeClear}
+            onNoticeClear={this.handleNoticeClear1}
             onMenuClick={this.handleMenuClick}
             onNoticeVisibleChange={this.handleNoticeVisibleChanged}
             {...this.props}
@@ -150,7 +150,7 @@ class HeaderView extends PureComponent {
         ) : (
           <GlobalHeader
             onCollapse={handleMenuCollapse}
-            onNoticeClear={this.handleNoticeClear}
+            onNoticeClear={this.handleNoticeClear1}
             onMenuClick={this.handleMenuClick}
             onNoticeVisibleChange={this.handleNoticeVisibleChanged}
             {...this.props}

--- a/src/layouts/Header.js
+++ b/src/layouts/Header.js
@@ -43,12 +43,16 @@ class HeaderView extends PureComponent {
   };
 
   handleNoticeClear = type => {
-    const { handleNoticeClear } = this.props
+    const { handleNoticeClear } = this.props;
     // 支持自定义
-    if(handleNoticeClear){
-      handleNoticeClear(type)
-    }else{
-      message.success(`${formatMessage({ id: 'component.noticeIcon.cleared' })} ${formatMessage({ id: `component.globalHeader.${type}` })}`);
+    if (handleNoticeClear) {
+      handleNoticeClear(type);
+    } else {
+      message.success(
+        `${formatMessage({ id: 'component.noticeIcon.cleared' })} ${formatMessage({
+          id: `component.globalHeader.${type}`,
+        })}`
+      );
       const { dispatch } = this.props;
       dispatch({
         type: 'global/clearNotices',
@@ -80,16 +84,15 @@ class HeaderView extends PureComponent {
 
   handleNoticeVisibleChanged = visible => {
     // 可外部定义此方法
-    const { handleNoticeVisibleChange } = this.props 
-    if(handleNoticeVisibleChange){
-      handleNoticeVisibleChange(visible)
-    }else if (visible) {
-        const { dispatch } = this.props;
-        dispatch({
-          type: 'global/fetchNotices',
-        });
-      }
-    
+    const { handleNoticeVisibleChange } = this.props;
+    if (handleNoticeVisibleChange) {
+      handleNoticeVisibleChange(visible);
+    } else if (visible) {
+      const { dispatch } = this.props;
+      dispatch({
+        type: 'global/fetchNotices',
+      });
+    }
   };
 
   handScroll = () => {

--- a/src/layouts/Header.js
+++ b/src/layouts/Header.js
@@ -43,12 +43,18 @@ class HeaderView extends PureComponent {
   };
 
   handleNoticeClear = type => {
-    message.success(`${formatMessage({ id: 'component.noticeIcon.cleared' })} ${formatMessage({ id: `component.globalHeader.${type}` })}`);
-    const { dispatch } = this.props;
-    dispatch({
-      type: 'global/clearNotices',
-      payload: type,
-    });
+    const { handleNoticeClear } = this.props
+    // 支持自定义
+    if(handleNoticeClear){
+      handleNoticeClear(type)
+    }else{
+      message.success(`${formatMessage({ id: 'component.noticeIcon.cleared' })} ${formatMessage({ id: `component.globalHeader.${type}` })}`);
+      const { dispatch } = this.props;
+      dispatch({
+        type: 'global/clearNotices',
+        payload: type,
+      });
+    }
   };
 
   handleMenuClick = ({ key }) => {
@@ -72,13 +78,18 @@ class HeaderView extends PureComponent {
     }
   };
 
-  handleNoticeVisibleChange = visible => {
-    if (visible) {
-      const { dispatch } = this.props;
-      dispatch({
-        type: 'global/fetchNotices',
-      });
-    }
+  handleNoticeVisibleChanged = visible => {
+    // 可外部定义此方法
+    const { handleNoticeVisibleChange } = this.props 
+    if(handleNoticeVisibleChange){
+      handleNoticeVisibleChange(visible)
+    }else if (visible) {
+        const { dispatch } = this.props;
+        dispatch({
+          type: 'global/fetchNotices',
+        });
+      }
+    
   };
 
   handScroll = () => {
@@ -130,7 +141,7 @@ class HeaderView extends PureComponent {
             onCollapse={handleMenuCollapse}
             onNoticeClear={this.handleNoticeClear}
             onMenuClick={this.handleMenuClick}
-            onNoticeVisibleChange={this.handleNoticeVisibleChange}
+            onNoticeVisibleChange={this.handleNoticeVisibleChanged}
             {...this.props}
           />
         ) : (
@@ -138,7 +149,7 @@ class HeaderView extends PureComponent {
             onCollapse={handleMenuCollapse}
             onNoticeClear={this.handleNoticeClear}
             onMenuClick={this.handleMenuClick}
-            onNoticeVisibleChange={this.handleNoticeVisibleChange}
+            onNoticeVisibleChange={this.handleNoticeVisibleChanged}
             {...this.props}
           />
         )}
@@ -152,10 +163,9 @@ class HeaderView extends PureComponent {
   }
 }
 
-export default connect(({ user, global, setting, loading }) => ({
+export default connect(({ user, global, setting }) => ({
   currentUser: user.currentUser,
   collapsed: global.collapsed,
-  fetchingNotices: loading.effects['global/fetchNotices'],
   notices: global.notices,
   setting,
 }))(HeaderView);


### PR DESCRIPTION
如果您想要扩展 BasicLayout ，同时又想通过更新ant-design-pro来获得antd-pro团队最新特性，可以通过包装BasicLayout实现
以下是BasicLayout 外部可定义props
 props = {
  onSearch, // 顶部搜索回调函数 function(value:string)
  onPressEnter, // 顶部搜索回车事件回调函数 function(value:string)
  searchDataSource, // 顶部搜索提示数据 string[]
  onItemClick,  // 消息记录点击事件回调函数 function(item:obect,tabprops:object)
  notificationTypes=['notification','message','event'], // 消息类型展示自定义
  notifyCount, // 总消息条数 value:number
  handleNoticeClear(type),// 清理消息回调函数
  fetchingNotices, // 消息面板显示时,加载图标状态显示控制
  handleNoticeVisibleChange,  // 消息面板展开事件 function(visible:boolean)
  menuData, // 菜单数据 ，object[],结构参考formatter
  pageTitle, // 页面title
 }