### PR TITLE
Update nginx.conf

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -4,7 +4,7 @@ server {
     gzip on;
     gzip_min_length 1k;
     gzip_comp_level 9;
-    gzip_types text/plain application/javascript application/x-javascript text/css application/xml text/javascript application/x-httpd-php image/jpeg image/gif image/png;
+    gzip_types text/plain text/css text/javascript application/json application/javascript application/x-javascript application/xml;
     gzip_vary on;
     gzip_disable "MSIE [1-6]\.";
 


### PR DESCRIPTION
禁用 image/jpeg image/gif image/png，因为图片启用Gzip压缩会适得其反；
启用 application/json，支持 json 数据的 Gzip 压缩。