### PR TITLE
BasicLayout 支持组装扩展 #2665

### DIFF
--- a/src/components/GlobalHeader/RightContent.js
+++ b/src/components/GlobalHeader/RightContent.js
@@ -123,7 +123,6 @@ export default class GlobalHeaderRight extends PureComponent {
         </Menu.Item>
       </Menu>
     );
-    const noticeData = this.getNoticeData();
     let className = styles.right;
     if (theme === 'dark') {
       className = `${styles.right}  ${styles.dark}`;

--- a/src/components/GlobalHeader/RightContent.js
+++ b/src/components/GlobalHeader/RightContent.js
@@ -40,6 +40,57 @@ export default class GlobalHeaderRight extends PureComponent {
     return groupBy(newNotices, 'type');
   }
 
+  /**
+   * 支持自定义搜索事件响应
+   */
+  onSearch = value => {
+    const { onSearch } = this.props;
+    if (onSearch) {
+      onSearch(value);
+    }
+  };
+
+  /**
+   * 支持自定义搜索回车事件响应
+   */
+  onPressEnter = value => {
+    const { onPressEnter } = this.props;
+    if (onPressEnter) {
+      onPressEnter(value);
+    }
+  };
+
+  /**
+   * 支持自定义通知记录点击事件
+   */
+  onItemClick = (item, tabProps) => {
+    const { onItemClick } = this.props;
+    if (onItemClick) {
+      onItemClick(item, tabProps);
+    }
+  };
+
+  /**
+   * 支持自定义消息面板可展示的类型
+   */
+  noticeIconTabs = () => {
+    const { notificationTypes = ['notification', 'message', 'event'] } = this.props;
+    const noticeData = this.getNoticeData();
+    const tabs = notificationTypes.map(item => (
+      <NoticeIcon.Tab
+        key={item}
+        list={noticeData[`${item}`]}
+        title={formatMessage({ id: `component.globalHeader.${item}` })}
+        name={`${item}`}
+        emptyText={formatMessage({ id: `component.globalHeader.${item}.empty` })}
+        emptyImage={`https://gw.alipayobjects.com/zos/rmsportal/${
+          item === 'message' ? 'sAuJeJzSKbUmHfBQRzmZ' : 'wAhyIChODzsoKIOBHcBk'
+        }.svg`}
+      />
+    ));
+    return tabs;
+  };
+
   render() {
     const {
       currentUser,
@@ -48,6 +99,8 @@ export default class GlobalHeaderRight extends PureComponent {
       onMenuClick,
       onNoticeClear,
       theme,
+      searchDataSource = [],
+      notifyCount,
     } = this.props;
     const menu = (
       <Menu className={styles.menu} selectedKeys={[]} onClick={onMenuClick}>
@@ -80,17 +133,9 @@ export default class GlobalHeaderRight extends PureComponent {
         <HeaderSearch
           className={`${styles.action} ${styles.search}`}
           placeholder={formatMessage({ id: 'component.globalHeader.search' })}
-          dataSource={[
-            formatMessage({ id: 'component.globalHeader.search.example1' }),
-            formatMessage({ id: 'component.globalHeader.search.example2' }),
-            formatMessage({ id: 'component.globalHeader.search.example3' }),
-          ]}
-          onSearch={value => {
-            console.log('input', value); // eslint-disable-line
-          }}
-          onPressEnter={value => {
-            console.log('enter', value); // eslint-disable-line
-          }}
+          dataSource={searchDataSource}
+          onSearch={this.onSearch}
+          onPressEnter={this.onPressEnter}
         />
         <Tooltip title={formatMessage({ id: 'component.globalHeader.help' })}>
           <a
@@ -104,10 +149,8 @@ export default class GlobalHeaderRight extends PureComponent {
         </Tooltip>
         <NoticeIcon
           className={styles.action}
-          count={currentUser.notifyCount}
-          onItemClick={(item, tabProps) => {
-            console.log(item, tabProps); // eslint-disable-line
-          }}
+          count={notifyCount || currentUser.notifyCount}
+          onItemClick={this.onItemClick}
           locale={{
             emptyText: formatMessage({ id: 'component.noticeIcon.empty' }),
             clear: formatMessage({ id: 'component.noticeIcon.clear' }),
@@ -118,27 +161,7 @@ export default class GlobalHeaderRight extends PureComponent {
           popupAlign={{ offset: [20, -16] }}
           clearClose
         >
-          <NoticeIcon.Tab
-            list={noticeData.notification}
-            title={formatMessage({ id: 'component.globalHeader.notification' })}
-            name="notification"
-            emptyText={formatMessage({ id: 'component.globalHeader.notification.empty' })}
-            emptyImage="https://gw.alipayobjects.com/zos/rmsportal/wAhyIChODzsoKIOBHcBk.svg"
-          />
-          <NoticeIcon.Tab
-            list={noticeData.message}
-            title={formatMessage({ id: 'component.globalHeader.message' })}
-            name="message"
-            emptyText={formatMessage({ id: 'component.globalHeader.message.empty' })}
-            emptyImage="https://gw.alipayobjects.com/zos/rmsportal/sAuJeJzSKbUmHfBQRzmZ.svg"
-          />
-          <NoticeIcon.Tab
-            list={noticeData.event}
-            title={formatMessage({ id: 'component.globalHeader.event' })}
-            name="event"
-            emptyText={formatMessage({ id: 'component.globalHeader.event.empty' })}
-            emptyImage="https://gw.alipayobjects.com/zos/rmsportal/HsIsxMZiWKrNUavQUXqx.svg"
-          />
+          {this.noticeIconTabs()}
         </NoticeIcon>
         {currentUser.name ? (
           <Dropdown overlay={menu}>

--- a/src/layouts/BasicLayout.js
+++ b/src/layouts/BasicLayout.js
@@ -144,8 +144,10 @@ class BasicLayout extends React.PureComponent {
   getMenuData() {
     const {
       route: { routes },
+      menuData,
     } = this.props;
-    return memoizeOneFormatter(routes);
+    // 支持通过 组合的方式定义菜单
+    return menuData ||enuData memoizeOneFormatter(routes);
   }
 
   /**
@@ -175,16 +177,18 @@ class BasicLayout extends React.PureComponent {
   };
 
   getPageTitle = pathname => {
+    const { pageTitle } = this.props;
     const currRouterData = this.matchParamsPath(pathname);
-
+    // 支持通过 组合的方式定义PageTitle
+    const title = pageTitle || 'Ant Design Pro';
     if (!currRouterData) {
-      return 'Ant Design Pro';
+      return title;
     }
     const message = formatMessage({
       id: currRouterData.locale || currRouterData.name,
       defaultMessage: currRouterData.name,
     });
-    return `${message} - Ant Design Pro`;
+    return `${message} - ${title}`;
   };
 
   getLayoutStyle = () => {
@@ -230,10 +234,15 @@ class BasicLayout extends React.PureComponent {
       layout: PropsLayout,
       children,
       location: { pathname },
+      loading,
+      fetchingNotices,
     } = this.props;
     const { isMobile, menuData } = this.state;
     const isTop = PropsLayout === 'topmenu';
     const routerConfig = this.matchParamsPath(pathname);
+    // 支持通过 组合的方式定义消息面板loading状态
+    const fetching = fetchingNotices || loading.effects['global/fetchNotices'];
+    const headerProps = { ...this.props, fetchingNotices: fetching };
     const layout = (
       <Layout>
         {isTop && !isMobile ? null : (
@@ -258,7 +267,7 @@ class BasicLayout extends React.PureComponent {
             handleMenuCollapse={this.handleMenuCollapse}
             logo={logo}
             isMobile={isMobile}
-            {...this.props}
+            {...headerProps}
           />
           <Content style={this.getContentStyle()}>
             <Authorized
@@ -288,9 +297,27 @@ class BasicLayout extends React.PureComponent {
     );
   }
 }
-
-export default connect(({ global, setting }) => ({
+/**
+ * 如果您想要扩展 BasicLayout ，同时又想通过更新ant-design-pro来获得antd-pro最新特性，可以通过新建组件组合BasicLayout实现
+ * 以下是BasicLayout可支持自定义的 props
+ * {
+ *  onSearch, // 顶部搜索钩子函数 function(value:string)
+ *  onPressEnter, // 顶部搜索回车事件钩子函数 function(value:string)
+ *  searchDataSource, // 顶部搜索提示数据 string[]
+ *  onItemClick,  // 消息面板的消息点击事件钩子函数 function(item:obect,tabprops:object)
+ *  notificationTypes=['notification','message','event'], // 可自定义消息面板可展示的类型
+ *  notifyCount, // 消息面板的消息总条数 value:number
+ *  handleNoticeClear(type),// 消息面板清理消息钩子函数
+ *  fetchingNotices, // 消息面板加载消息的loading状态
+ *  handleNoticeVisibleChange,  // 消息面板显示事件钩子函数 function(visible:boolean)
+ *  menuData, // 菜单数据 ，object[], 结构参考路由配置和formatter方法逻辑
+ *  pageTitle, // 页面title
+ * }
+ */
+export default connect(({ global, setting,loading }) => ({
   collapsed: global.collapsed,
   layout: setting.layout,
+  loading,
+  // pageTitle:"antd-pro-title",
   ...setting,
 }))(BasicLayout);

--- a/src/layouts/BasicLayout.js
+++ b/src/layouts/BasicLayout.js
@@ -147,7 +147,7 @@ class BasicLayout extends React.PureComponent {
       menuData,
     } = this.props;
     // 支持通过 组合的方式定义菜单
-    return menuData ||enuData memoizeOneFormatter(routes);
+    return menuData || memoizeOneFormatter(routes);
   }
 
   /**

--- a/src/layouts/Header.js
+++ b/src/layouts/Header.js
@@ -43,6 +43,12 @@ class HeaderView extends PureComponent {
   };
 
   handleNoticeClear = type => {
+    // 支持自定义消息清空方法
+    const { handleNoticeClear } = this.props;
+    if(handleNoticeClear){
+      handleNoticeClear(type)
+      return 
+    }
     message.success(
       `${formatMessage({ id: 'component.noticeIcon.cleared' })} ${formatMessage({
         id: `component.globalHeader.${type}`,
@@ -77,6 +83,12 @@ class HeaderView extends PureComponent {
   };
 
   handleNoticeVisibleChange = visible => {
+    // 支持自定义消息面板显示时的钩子函数
+    const { handleNoticeVisibleChange } = this.props;
+    if(handleNoticeVisibleChange){
+      handleNoticeVisibleChange(visible)
+      return 
+    }
     if (visible) {
       const { dispatch } = this.props;
       dispatch({


### PR DESCRIPTION
如果您想要扩展 BasicLayout ，同时又想通过更新ant-design-pro来获得antd-pro最新特性，可以通过新建组件组合BasicLayout实现
以下是BasicLayout可支持自定义的 props
 {
  onSearch, // 顶部搜索钩子函数 function(value:string)
  onPressEnter, // 顶部搜索回车事件钩子函数 function(value:string)
  searchDataSource, // 顶部搜索提示数据 string[]
  onItemClick,  // 消息面板的消息点击事件钩子函数 function(item:obect,tabprops:object)
  notificationTypes=['notification','message','event'], // 可自定义消息面板可展示的类型
  notifyCount, // 消息面板的消息总条数 value:number
  handleNoticeClear(type),// 消息面板清理消息钩子函数
  fetchingNotices, // 消息面板加载消息的loading状态
  handleNoticeVisibleChange,  // 消息面板显示事件钩子函数 function(visible:boolean)
  menuData, // 菜单数据 ，object[], 结构参考路由配置和formatter方法逻辑
  pageTitle, // 页面title
 }