### PR TITLE
adjust production environment judgment conditions

### DIFF
--- a/src/layouts/BasicLayout.js
+++ b/src/layouts/BasicLayout.js
@@ -218,7 +218,7 @@ class BasicLayout extends React.PureComponent {
     // Do not render SettingDrawer in production
     // unless it is deployed in preview.pro.ant.design as demo
     const { rendering } = this.state;
-    if ((rendering || process.env.NODE_ENV === 'production') && APP_TYPE !== 'site') {
+    if (rendering || window.ORIGIN_NODE_ENV === 'production') {
       return null;
     }
     return <SettingDrawer />;

--- a/src/models/setting.js
+++ b/src/models/setting.js
@@ -4,7 +4,7 @@ import defaultSettings from '../defaultSettings';
 let lessNodesAppended;
 const updateTheme = primaryColor => {
   // Don't compile less in production!
-  if (APP_TYPE !== 'site') {
+  if (window.ORIGIN_NODE_ENV !== 'site') {
     return;
   }
   // Determine if the component is remounted

--- a/src/pages/document.ejs
+++ b/src/pages/document.ejs
@@ -5,6 +5,9 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Ant Design Pro</title>
+  <script>
+    window.ORIGIN_NODE_ENV='<%= context.env %>';
+   </script>
   <link rel="icon" href="/favicon.png" type="image/x-icon">
   <script src="https://gw.alipayobjects.com/os/antv/pkg/_antv.data-set-0.9.6/dist/data-set.min.js"></script>
 </head>


### PR DESCRIPTION
After reading the documentation of umijs, as I understand it, APP_TYPE is just a deployment mode, not suitable for distinguishing between development environment and production environment, and the APP_TYPE value here should be equal to undefined.
看了umijs的文档后，按照我的理解，APP_TYPE只是一种部署模式，不适合用来区分开发环境和生产环境,而且此处的APP_TYPE值应该恒等于undefined;