### PR TITLE
bug: fix authorities of root route were not be injected in Authorized…

### DIFF
--- a/src/layouts/BasicLayout.js
+++ b/src/layouts/BasicLayout.js
@@ -143,9 +143,9 @@ class BasicLayout extends React.PureComponent {
 
   getMenuData() {
     const {
-      route: { routes },
+      route: { routes, path, authority },
     } = this.props;
-    return memoizeOneFormatter(routes);
+    return memoizeOneFormatter(routes, path, authority);
   }
 
   /**


### PR DESCRIPTION
基本页面布局组件中的根路由丢失，BasicLayout.js render()中的Authorized组件prop authority取用的routerConfig.authority为undefined，这与实际的根路由配置的authority: ['admin', 'user']不符