### PR TITLE
fixed the login component not pass the object children

### DIFF
--- a/src/components/Login/index.js
+++ b/src/components/Login/index.js
@@ -113,9 +113,7 @@ class Login extends Component {
                 </Tabs>
                 {otherChildren}
               </React.Fragment>
-            ) : (
-              [...children]
-            )}
+            ) : children}
           </Form>
         </div>
       </LoginContext.Provider>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22249411/48753648-bb508c80-ecc9-11e8-9842-8724c2b12013.png)
![image](https://user-images.githubusercontent.com/22249411/48753659-c4415e00-ecc9-11e8-8569-2f88be3e003b.png)
![image](https://user-images.githubusercontent.com/22249411/48753678-da4f1e80-ecc9-11e8-9b5f-67ff8769e485.png)

when the children is object.


![image](https://user-images.githubusercontent.com/22249411/48753694-ee931b80-ecc9-11e8-8ff4-bdc2d35fe988.png)
![image](https://user-images.githubusercontent.com/22249411/48753705-fb177400-ecc9-11e8-8967-b357130de05c.png)
![image](https://user-images.githubusercontent.com/22249411/48753720-04a0dc00-ecca-11e8-993c-6a380b8f033b.png)


when the children is array.

`[...children] should be changed the `children` for self-defined.