### PR TITLE
Enable hash suffix for the built files by default

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -56,6 +56,8 @@ if (process.env.APP_TYPE === 'site') {
 export default {
   // add for transfer to umi
   plugins,
+  // enable hash suffix for the built files
+  hash: true,
   targets: {
     ie: 11,
   },


### PR DESCRIPTION
In case of browser cache, It's preferable to  enable hash suffix by default.