### PR TITLE
fix header will be visible and then immediately hide when scroll up

### DIFF
--- a/src/layouts/Header.js
+++ b/src/layouts/Header.js
@@ -99,12 +99,12 @@ class HeaderView extends PureComponent {
             visible: true,
           });
         }
-        if (scrollTop > 300 && visible) {
+        else if (scrollTop > 300 && visible) {
           this.setState({
             visible: false,
           });
         }
-        if (scrollTop < 300 && !visible) {
+        else if (scrollTop < 300 && !visible) {
           this.setState({
             visible: true,
           });


### PR DESCRIPTION
reproduce steps in [preview](https://preview.pro.ant.design/dashboard/analysis?fixedHeader=1&autoHideHeader=1):
1. switch on fixed header
1. switch on hide header when scroll down
1. scroll down much!!
1. scroll up once
1. header show and immediately hide