### PR TITLE
Fixed TagSelect can't clear value when Form run resetFields

### DIFF
--- a/src/components/TagSelect/index.js
+++ b/src/components/TagSelect/index.js
@@ -28,8 +28,8 @@ class TagSelect extends Component {
   }
 
   static getDerivedStateFromProps(nextProps) {
-    if ('value' in nextProps && nextProps.value) {
-      return { value: nextProps.value };
+    if ('value' in nextProps) {
+      return { value: nextProps.value || [] };
     }
     return null;
   }


### PR DESCRIPTION
Using **TagSelect** in the **Form** component, the value of **TagSelect** can‘t be cleared when running `resetFields`.