### PR TITLE
fix: 解决当 path 带有参数信息时，会导致权限判断失效

### DIFF
--- a/src/layouts/BasicLayout.js
+++ b/src/layouts/BasicLayout.js
@@ -100,7 +100,7 @@ class BasicLayout extends React.PureComponent {
     let routeAuthority = ['noAuthority'];
     const getAuthority = (key, routes) => {
       routes.map(route => {
-        if (route.path === key) {
+        if (route.path && pathToRegexp(route.path).test(key)) {
           routeAuthority = route.authority;
         } else if (route.routes) {
           routeAuthority = getAuthority(key, route.routes);


### PR DESCRIPTION
加上 router.path 为空的判断是因为我发现实际 routeData 会存在没有 path 的状况
Close: #3084