### PR TITLE
fix: less compile bug

### DIFF
--- a/src/components/HeaderDropdown/index.less
+++ b/src/components/HeaderDropdown/index.less
@@ -1,6 +1,6 @@
 @import '~antd/lib/style/themes/default.less';
 
-.container > *:global(:not(.ant-dropdown-menu)) {
+.container > *:not(.ant-dropdown-menu) {
   background-color: #fff;
   box-shadow: @shadow-1-down;
   border-radius: 4px;

--- a/src/components/HeaderDropdown/index.less
+++ b/src/components/HeaderDropdown/index.less
@@ -1,6 +1,6 @@
 @import '~antd/lib/style/themes/default.less';
 
-.container > *:not(.ant-dropdown-menu) {
+.container :global(.ant-tabs) {
   background-color: #fff;
   box-shadow: @shadow-1-down;
   border-radius: 4px;

--- a/src/components/HeaderDropdown/index.less
+++ b/src/components/HeaderDropdown/index.less
@@ -1,6 +1,6 @@
 @import '~antd/lib/style/themes/default.less';
 
-.container :global(.ant-tabs) {
+.container > * {
   background-color: #fff;
   box-shadow: @shadow-1-down;
   border-radius: 4px;


### PR DESCRIPTION
#3079 
.container > *:global(:not(.ant-dropdown-menu)){}自动被编译成了:not(.ant-dropdown-menu){}