### PR TITLE
fix: reload menu open question

### DIFF
--- a/src/components/SiderMenu/BaseMenu.js
+++ b/src/components/SiderMenu/BaseMenu.js
@@ -126,6 +126,7 @@ export default class BaseMenu extends PureComponent {
       mode,
       location: { pathname },
       className,
+      collapsed,
     } = this.props;
     // if pathname can't match, use the nearest parent's key
     let selectedKeys = this.getSelectedMenuKeys(pathname);
@@ -133,9 +134,9 @@ export default class BaseMenu extends PureComponent {
       selectedKeys = [openKeys[openKeys.length - 1]];
     }
     let props = {};
-    if (openKeys) {
+    if (openKeys && !collapsed) {
       props = {
-        openKeys,
+        openKeys: openKeys.length === 0 ? [...selectedKeys] : openKeys,
       };
     }
     const { handleOpenChange, style, menuData } = this.props;


### PR DESCRIPTION
 collapsed 为false时，刷新后菜单的openKeys为[]时，导致菜单不展开的问题