### PR TITLE
request.js的异常情况考虑得不全面

### DIFF
--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -150,6 +150,7 @@ export default function request(url, option) {
       }
       else if (status >= 404 && status < 422) {
         router.push('/exception/404');
+        return;
       } else {
         router.push('/login');
         return;


### PR DESCRIPTION

除了4和5开头的异常之外，还有其它异常e.name不存在的异常，此时将console.log(e)打印出来的信息是：TypeError: Failed to fetch
在我公司项目中，这种场景下是需要跳转到登陆页的，因此将上述代码做了微小修改，请同意合并PR，谢谢。如有疑问请联系我34982452@qq.com