### PR TITLE
修复 HeaderSearch 的 onSearch 回调

### DIFF
--- a/src/components/HeaderSearch/index.js
+++ b/src/components/HeaderSearch/index.js
@@ -11,6 +11,7 @@ export default class HeaderSearch extends PureComponent {
     className: PropTypes.string,
     placeholder: PropTypes.string,
     onSearch: PropTypes.func,
+    onChange: PropTypes.func,
     onPressEnter: PropTypes.func,
     defaultActiveFirstOption: PropTypes.bool,
     dataSource: PropTypes.array,
@@ -22,6 +23,7 @@ export default class HeaderSearch extends PureComponent {
     defaultActiveFirstOption: false,
     onPressEnter: () => {},
     onSearch: () => {},
+    onChange: () => {},
     className: '',
     placeholder: '',
     dataSource: [],
@@ -61,11 +63,12 @@ export default class HeaderSearch extends PureComponent {
   };
 
   onChange = value => {
-    const { onChange } = this.props;
+    const { onSearch, onChange } = this.props;
     this.setState({ value });
-    if (onChange) {
+    if (onSearch)
+      onSearch(value);
+    if (onChange)
       onChange(value);
-    }
   };
 
   enterSearchMode = () => {

--- a/src/components/HeaderSearch/index.js
+++ b/src/components/HeaderSearch/index.js
@@ -65,10 +65,12 @@ export default class HeaderSearch extends PureComponent {
   onChange = value => {
     const { onSearch, onChange } = this.props;
     this.setState({ value });
-    if (onSearch)
-      onSearch(value);
-    if (onChange)
-      onChange(value);
+    if (onSearch){
+        onSearch(value);
+    }
+    if (onChange){
+        onChange(value);
+    }
   };
 
   enterSearchMode = () => {


### PR DESCRIPTION
修复 #3222  问题，在使用 HeaderSearch组件时，可以选择使用 `onSearch` 或者 `onChange ` 方法。


使用方式：
```
    <HeaderSearch
          className={`${styles.action} ${styles.search}`}
          placeholder={formatMessage({ id: 'component.globalHeader.search' })}
          dataSource={[
            formatMessage({ id: 'component.globalHeader.search.example1' }),
            formatMessage({ id: 'component.globalHeader.search.example2' }),
            formatMessage({ id: 'component.globalHeader.search.example3' }),
          ]}
          onSearch={value => {
            console.log('search-input', value); // eslint-disable-line
          }}
          onChange={value => {
            console.log('change-input', value); // eslint-disable-line
          }}
          onPressEnter={value => {
            console.log('enter', value); // eslint-disable-line
          }}
        />

```