### PR TITLE
fix: Ellipsis webkitLineClamp

### DIFF
--- a/src/components/Ellipsis/index.js
+++ b/src/components/Ellipsis/index.js
@@ -6,7 +6,7 @@ import styles from './index.less';
 /* eslint react/no-did-mount-set-state: 0 */
 /* eslint no-param-reassign: 0 */
 
-const isSupportLineClamp = document.body.style.webkitLineClamp !== undefined;
+const isSupportLineClamp = document.body.style['webkitLineClamp'] !== undefined;
 
 const TooltipOverlayStyle = {
   overflowWrap: 'break-word',


### PR DESCRIPTION
support Typescript better for later.