### PR TITLE
fix: Ellipsis types

### DIFF
--- a/src/components/Ellipsis/index.d.ts
+++ b/src/components/Ellipsis/index.d.ts
@@ -16,6 +16,6 @@ export interface IEllipsisProps {
 }
 
 export function getStrFullLength(str: string): number;
-export function cutStrByFullLength(str: string, maxLength: number): number;
+export function cutStrByFullLength(str: string, maxLength: number): string;
 
 export default class Ellipsis extends React.Component<IEllipsisProps, any> {}


### PR DESCRIPTION
cutStrByFullLength should be string