### PR TITLE
Fix NoticeIcon tab typings for skeletonProps

### DIFF
--- a/src/components/NoticeIcon/NoticeIconTab.d.ts
+++ b/src/components/NoticeIcon/NoticeIconTab.d.ts
@@ -20,7 +20,7 @@ export interface INoticeIconTabProps {
   name?: string;
   showClear?: boolean;
   skeletonCount?: number;
-  skeletonProps: SkeletonProps;
+  skeletonProps?: SkeletonProps;
   style?: React.CSSProperties;
   title?: string;
 }


### PR DESCRIPTION
The attribute `skeletonProps` in NoticeIcon tab has default value of `{}` so it doesn't necessary have to be required as stated in typings. This PR fixes it be optional.