### PR TITLE
Make "home" optional in breadcrumb

### DIFF
--- a/src/components/PageHeader/breadcrumb.js
+++ b/src/components/PageHeader/breadcrumb.js
@@ -100,18 +100,20 @@ export default class BreadcrumbView extends PureComponent {
         </Breadcrumb.Item>
       ) : null;
     });
-    // Add home breadcrumbs to your head
-    extraBreadcrumbItems.unshift(
-      <Breadcrumb.Item key="home">
-        {createElement(
-          linkElement,
-          {
-            [linkElement === 'a' ? 'href' : 'to']: '/',
-          },
-          home || 'Home'
-        )}
-      </Breadcrumb.Item>
-    );
+    // Add home breadcrumbs to your head if defined
+    if (home) {
+      extraBreadcrumbItems.unshift(
+        <Breadcrumb.Item key="home">
+          {createElement(
+            linkElement,
+            {
+              [linkElement === 'a' ? 'href' : 'to']: '/',
+            },
+            home
+          )}
+        </Breadcrumb.Item>
+      );
+    }
     return (
       <Breadcrumb className={styles.breadcrumb} separator={breadcrumbSeparator}>
         {extraBreadcrumbItems}


### PR DESCRIPTION
In current implementation, if the home prop is empty, the component will show plain English text "Home", which is not ideal (not I18n'ed). This PR propose that simply don't show the text at all.

In some cases, the console only has one level of menus on the left and there is no "Home" concept for the whole app.

If the developer wants to include Home, it's already defined in the current WrappedPageHeader component.

Test: worked in dev.