### PR TITLE
Fix an issue in list item Add

### DIFF
--- a/src/pages/List/BasicList.js
+++ b/src/pages/List/BasicList.js
@@ -322,7 +322,7 @@ class BasicList extends PureComponent {
           </Card>
         </div>
         <Modal
-          title={done ? null : `任务${current ? '编辑' : '添加'}`}
+          title={done ? null : `任务${current.id ? '编辑' : '添加'}`}
           className={styles.standardListForm}
           width={640}
           bodyStyle={done ? { padding: '72px 0' } : { padding: '28px 0 0' }}


### PR DESCRIPTION
the model will show "编辑订单" in the title even if a user clicks on the "+" because the `current` variable has a default `{}` in the assignment. We should check `current.id` to decide the model title copy.

before:
![0118-ant-basiclist-bug](https://user-images.githubusercontent.com/1766793/51367075-e289d580-1b23-11e9-9838-d92ebdfa3eda.gif)

after:
![0118-ant-basiclist-bugfix](https://user-images.githubusercontent.com/1766793/51367111-0baa6600-1b24-11e9-8105-ab21d1365513.gif)
