### PR TITLE
auto start a server when run tests

### DIFF
--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -10,4 +10,10 @@ module.exports = {
       '--no-zygote',
     ],
   },
+  server: {
+    command: `npm start`,
+    port: 8000,
+    launchTimeout: 10000,
+    debug: true,
+  },
 };


### PR DESCRIPTION
I do not want to do 'npm start' manually before a unit test each time, fortunately, Puppeteer provides a config filed to help me figure out this.