### PR TITLE
Fix "Cannot read property 'isRootMenu' of undefined" when passing a p…

### DIFF
--- a/src/components/Authorized/PromiseRender.js
+++ b/src/components/Authorized/PromiseRender.js
@@ -40,7 +40,7 @@ export default class PromiseRender extends React.PureComponent {
     if (!React.isValidElement(target)) {
       return target;
     }
-    return () => target;
+    return (props) => React.cloneElement(target, {...props});
   };
 
   render() {


### PR DESCRIPTION
…romise as authority to checkPermissions

In current implementation, when a promise authority object is passed in, checkPermissions function is going to use PromiseRender component to handle the promise. In the case when the rendering target is an instantiated react component, the function `checkIsInstantiation` in PromiseRender is returning `() => target` as an new stateless component which is being used in render() as the component to be Instantiated and return `<Component {...rest} />`;

*Problem here:*
The rest prop couldn't be injected into the target component

*Fix:*
Instead of returning `() => target`, the checkIsInstantiation method should return `(props) => React.cloneElement(target, {...props})`