### PR TITLE
Fix submenu collapsed when refresh page

### DIFF
--- a/src/components/SiderMenu/SiderMenu.js
+++ b/src/components/SiderMenu/SiderMenu.js
@@ -18,10 +18,14 @@ export default class SiderMenu extends PureComponent {
   }
 
   static getDerivedStateFromProps(props, state) {
-    const { pathname } = state;
-    if (props.location.pathname !== pathname) {
+    const { pathname, flatMenuKeysLen } = state;
+    if (
+      props.location.pathname !== pathname ||
+      props.flatMenuKeys.length !== flatMenuKeysLen
+    ) {
       return {
         pathname: props.location.pathname,
+        flatMenuKeysLen: props.flatMenuKeys.length,
         openKeys: getDefaultCollapsedSubMenus(props),
       };
     }


### PR DESCRIPTION
When first visit the page, submenu is expanded. When refresh the page, the submenu collapsed.
![image](https://user-images.githubusercontent.com/12318032/52029897-46fb5a80-2550-11e9-983e-259d6bd4528a.png)
![image](https://user-images.githubusercontent.com/12318032/52029905-4fec2c00-2550-11e9-8fcd-233f25bbccfd.png)
