### PR TITLE
fix customize menu icon bug

### DIFF
--- a/src/components/SiderMenu/BaseMenu.js
+++ b/src/components/SiderMenu/BaseMenu.js
@@ -15,7 +15,7 @@ const { SubMenu } = Menu;
 //   icon: <Icon type="setting" />,
 const getIcon = icon => {
   if (typeof icon === 'string' && isUrl(icon)) {
-    return <img src={icon} alt="icon" className={styles.icon} />;
+    return <Icon component={() => <img src={icon} alt="icon" className={styles.icon} />} />;
   }
   if (typeof icon === 'string') {
     return <Icon type={icon} />;

--- a/src/components/SiderMenu/index.less
+++ b/src/components/SiderMenu/index.less
@@ -66,8 +66,8 @@
 }
 
 .icon {
+  vertical-align: baseline;
   width: 14px;
-  margin-right: 10px;
 }
 
 :global {


### PR DESCRIPTION
当菜单图标采用url方式引入且菜单折叠时文字不隐藏，如下图所示
![image](https://user-images.githubusercontent.com/17609173/52349517-b518b380-2a61-11e9-96ce-5bceb901cdbb.png)
