### PR TITLE
fix: Eslint warning of Mock dependence

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,7 +24,7 @@ module.exports = {
       2,
       {
         optionalDependencies: true,
-        devDependencies: ['**/tests/**.js', '/mock/**.js', '**/**.test.js'],
+        devDependencies: ['**/tests/**.js', '/mock/**/**.js', '**/**.test.js'],
       },
     ],
     'jsx-a11y/no-noninteractive-element-interactions': 0,


### PR DESCRIPTION
解决当需要在mock文件夹下建立子文件夹时，Eslint的警告问题。