### PR TITLE
Use Umi Permission Routing

### DIFF
--- a/config/router.config.js
+++ b/config/router.config.js
@@ -19,7 +19,6 @@ export default [
     path: '/',
     component: '../layouts/BasicLayout',
     Routes: ['src/pages/Authorized'],
-    authority: ['admin', 'user'],
     routes: [
       // dashboard
       { path: '/', redirect: '/dashboard/analysis' },

--- a/src/layouts/BasicLayout.js
+++ b/src/layouts/BasicLayout.js
@@ -4,14 +4,11 @@ import DocumentTitle from 'react-document-title';
 import { connect } from 'dva';
 import { ContainerQuery } from 'react-container-query';
 import classNames from 'classnames';
-import pathToRegexp from 'path-to-regexp';
 import Media from 'react-media';
-import Authorized from '@/utils/Authorized';
 import logo from '../assets/logo.svg';
 import Footer from './Footer';
 import Header from './Header';
 import Context from './MenuContext';
-import Exception403 from '../pages/Exception/403';
 import PageLoading from '@/components/PageLoading';
 import SiderMenu from '@/components/SiderMenu';
 import getPageTitle from '@/utils/getPageTitle';
@@ -73,29 +70,6 @@ class BasicLayout extends React.Component {
     };
   }
 
-  getRouteAuthority = (pathname, routeData) => {
-    const routes = routeData.slice(); // clone
-
-    const getAuthority = (routeDatas, path) => {
-      let authorities;
-      routeDatas.forEach(route => {
-        // check partial route
-        if (pathToRegexp(`${route.path}(.*)`).test(path)) {
-          if (route.authority) {
-            authorities = route.authority;
-          }
-          // is exact route?
-          if (!pathToRegexp(route.path).test(path) && route.routes) {
-            authorities = getAuthority(route.routes, path);
-          }
-        }
-      });
-      return authorities;
-    };
-
-    return getAuthority(routes, pathname);
-  };
-
   getLayoutStyle = () => {
     const { fixSiderbar, isMobile, collapsed, layout } = this.props;
     if (fixSiderbar && layout !== 'topmenu' && !isMobile) {
@@ -132,12 +106,10 @@ class BasicLayout extends React.Component {
       isMobile,
       menuData,
       breadcrumbNameMap,
-      route: { routes },
       fixedHeader,
     } = this.props;
 
     const isTop = PropsLayout === 'topmenu';
-    const routerConfig = this.getRouteAuthority(pathname, routes);
     const contentStyle = !fixedHeader ? { paddingTop: 0 } : {};
     const layout = (
       <Layout>
@@ -165,9 +137,7 @@ class BasicLayout extends React.Component {
             {...this.props}
           />
           <Content className={styles.content} style={contentStyle}>
-            <Authorized authority={routerConfig} noMatch={<Exception403 />}>
-              {children}
-            </Authorized>
+            {children}
           </Content>
           <Footer />
         </Layout>

--- a/src/models/menu.js
+++ b/src/models/menu.js
@@ -97,6 +97,7 @@ export default {
 
   state: {
     menuData: [],
+    routerData: [],
     breadcrumbNameMap: {},
   },
 
@@ -107,7 +108,7 @@ export default {
       const breadcrumbNameMap = memoizeOneGetBreadcrumbNameMap(menuData);
       yield put({
         type: 'save',
-        payload: { menuData, breadcrumbNameMap },
+        payload: { menuData, breadcrumbNameMap, routerData: routes },
       });
     },
   },

--- a/src/pages/Authorized.js
+++ b/src/pages/Authorized.js
@@ -1,13 +1,47 @@
-import React from 'react';
-import RenderAuthorized from '@/components/Authorized';
-import { getAuthority } from '@/utils/authority';
+import React, { Component } from 'react';
 import Redirect from 'umi/redirect';
+import pathToRegexp from 'path-to-regexp';
+import { connect } from 'dva';
+import Authorized from '@/utils/Authorized';
 
-const Authority = getAuthority();
-const Authorized = RenderAuthorized(Authority);
+class AuthComponent extends Component {
+  render() {
+    const { children, location, routerData, status } = this.props;
+    const isLogin = status === 'ok';
 
-export default ({ children }) => (
-  <Authorized authority={children.props.route.authority} noMatch={<Redirect to="/user/login" />}>
-    {children}
-  </Authorized>
-);
+    const getRouteAuthority = (pathname, routeData) => {
+      const routes = routeData.slice(); // clone
+
+      const getAuthority = (routeDatas, path) => {
+        let authorities;
+        routeDatas.forEach(route => {
+          // check partial route
+          if (pathToRegexp(`${route.path}(.*)`).test(path)) {
+            if (route.authority) {
+              authorities = route.authority;
+            }
+            // is exact route?
+            if (!pathToRegexp(route.path).test(path) && route.routes) {
+              authorities = getAuthority(route.routes, path);
+            }
+          }
+        });
+        return authorities;
+      };
+
+      return getAuthority(routes, pathname);
+    };
+    return (
+      <Authorized
+        authority={getRouteAuthority(location.pathname, routerData)}
+        noMatch={isLogin ? <Redirect to="/exception/403" /> : <Redirect to="/user/login" />}
+      >
+        {children}
+      </Authorized>
+    );
+  }
+}
+export default connect(({ menu: menuModel, login: loginModel }) => ({
+  routerData: menuModel.routerData,
+  status: loginModel.status,
+}))(AuthComponent);

--- a/src/pages/Authorized.js
+++ b/src/pages/Authorized.js
@@ -1,45 +1,42 @@
-import React, { Component } from 'react';
+import React from 'react';
 import Redirect from 'umi/redirect';
 import pathToRegexp from 'path-to-regexp';
 import { connect } from 'dva';
 import Authorized from '@/utils/Authorized';
 
-class AuthComponent extends Component {
-  render() {
-    const { children, location, routerData, status } = this.props;
-    const isLogin = status === 'ok';
+function AuthComponent({ children, location, routerData, status }) {
+  const isLogin = status === 'ok';
 
-    const getRouteAuthority = (pathname, routeData) => {
-      const routes = routeData.slice(); // clone
+  const getRouteAuthority = (pathname, routeData) => {
+    const routes = routeData.slice(); // clone
 
-      const getAuthority = (routeDatas, path) => {
-        let authorities;
-        routeDatas.forEach(route => {
-          // check partial route
-          if (pathToRegexp(`${route.path}(.*)`).test(path)) {
-            if (route.authority) {
-              authorities = route.authority;
-            }
-            // is exact route?
-            if (!pathToRegexp(route.path).test(path) && route.routes) {
-              authorities = getAuthority(route.routes, path);
-            }
+    const getAuthority = (routeDatas, path) => {
+      let authorities;
+      routeDatas.forEach(route => {
+        // check partial route
+        if (pathToRegexp(`${route.path}(.*)`).test(path)) {
+          if (route.authority) {
+            authorities = route.authority;
           }
-        });
-        return authorities;
-      };
-
-      return getAuthority(routes, pathname);
+          // is exact route?
+          if (!pathToRegexp(route.path).test(path) && route.routes) {
+            authorities = getAuthority(route.routes, path);
+          }
+        }
+      });
+      return authorities;
     };
-    return (
-      <Authorized
-        authority={getRouteAuthority(location.pathname, routerData)}
-        noMatch={isLogin ? <Redirect to="/exception/403" /> : <Redirect to="/user/login" />}
-      >
-        {children}
-      </Authorized>
-    );
-  }
+
+    return getAuthority(routes, pathname);
+  };
+  return (
+    <Authorized
+      authority={getRouteAuthority(location.pathname, routerData)}
+      noMatch={isLogin ? <Redirect to="/exception/403" /> : <Redirect to="/user/login" />}
+    >
+      {children}
+    </Authorized>
+  );
 }
 export default connect(({ menu: menuModel, login: loginModel }) => ({
   routerData: menuModel.routerData,


### PR DESCRIPTION
1、把权限路由从布局里面中移除，感觉更加规范一点。
2、menu中新增了一个routerData，用于保存从配置或者服务端下发的原始的路由数据。
3、在权限路由中判断路由的权限和是否登录，感觉更贴合实际的使用场景。
4、删除了路由配置中根目录的权限设置，因为现在权限有继承关系。
5、注意：高级表单页面的权限有在runtime里面做了权限追加，所以登录user时，有访问权限，可以使用高级详情页，测试权限路由可用。/profile/advanced

其实如果动态菜单和动态权限都从服务端获取的话，那menuData和routerData大概长这样子：
```js
menuData:{
    routes: [
      // dashboard
      {
        path: '/dashboard',
        name: 'dashboard',
        icon: 'dashboard',
        routes: [
          {
            path: '/dashboard/analysis',
            name: 'analysis',
          },
          {
            path: '/dashboard/monitor',
            name: 'monitor',
          },
          {
            path: '/dashboard/workplace',
            name: 'workplace',
          },
        ],
      },
   ]
}
```
```js
routerData:{
    routes: [
      // dashboard
      {
        path: '/dashboard',
        authority: ['admin'],
        routes: [
          {
            path: '/dashboard/analysis',
             authority: ['admin','user'],
          },
        ],
      },
   ]
}
```
保持原来的配置写法也可以。