### PR TITLE
fix the problem that breadcrumbNameMap does not contain hidden menus.

### DIFF
--- a/src/models/menu.js
+++ b/src/models/menu.js
@@ -103,8 +103,9 @@ export default {
   effects: {
     *getMenuData({ payload }, { put }) {
       const { routes, authority } = payload;
-      const menuData = filterMenuData(memoizeOneFormatter(routes, authority));
-      const breadcrumbNameMap = memoizeOneGetBreadcrumbNameMap(menuData);
+      const originalMenuData = memoizeOneFormatter(routes, authority);
+      const menuData = filterMenuData(originalMenuData);
+      const breadcrumbNameMap = memoizeOneGetBreadcrumbNameMap(originalMenuData);
       yield put({
         type: 'save',
         payload: { menuData, breadcrumbNameMap },


### PR DESCRIPTION
When hideInMenu is set to true in router.config.js, these hidden menus are not included in the breadcrumbNameMap, causing the breadcrumbs to appear empty. This commit fixes this problem.