### PR TITLE
Optimize asset chunking

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -75,10 +75,6 @@ export default {
   theme: {
     'primary-color': primaryColor,
   },
-  externals: {
-    '@antv/data-set': 'DataSet',
-    bizcharts: 'BizCharts',
-  },
   // proxy: {
   //   '/server/api/': {
   //     target: 'https://preview.pro.ant.design/',

--- a/config/plugin.config.js
+++ b/config/plugin.config.js
@@ -53,7 +53,7 @@ export default config => {
   config.optimization
     .runtimeChunk(false) // share the same chunks across different modules
     .splitChunks({
-      chunks: 'all',
+      chunks: 'async',
       name: 'vendors',
       maxInitialRequests: Infinity,
       minSize: 0,
@@ -62,7 +62,7 @@ export default config => {
           test: module => {
             const packageName = getModulePackageName(module);
             if (packageName) {
-              return ['bizcharts', '@antv_data-set', '@ant-design_icons'].indexOf(packageName) >= 0;
+              return ['bizcharts', '@antv_data-set'].indexOf(packageName) >= 0;
             }
             return false;
           },
@@ -71,9 +71,6 @@ export default config => {
 
             if (['bizcharts', '@antv_data-set'].indexOf(packageName) >= 0) {
               return 'viz'; // visualization package
-            }
-            if (packageName === '@ant-design_icons') {
-              return 'icons';
             }
             return 'misc';
           },

--- a/config/plugin.config.js
+++ b/config/plugin.config.js
@@ -4,6 +4,24 @@ import MergeLessPlugin from 'antd-pro-merge-less';
 import AntDesignThemePlugin from 'antd-theme-webpack-plugin';
 import path from 'path';
 
+function getModulePackageName(module) {
+  if (!module.context) return null;
+
+  const nodeModulesPath = path.join(__dirname, '../node_modules/');
+  if (module.context.substring(0, nodeModulesPath.length) !== nodeModulesPath) {
+    return null;
+  }
+
+  const moduleRelativePath = module.context.substring(nodeModulesPath.length);
+  const [moduleDirName] = moduleRelativePath.split(path.sep);
+  let packageName = moduleDirName;
+  // handle tree shaking
+  if (packageName.match('^_')) {
+    packageName = packageName.match(/^_(@?[^@]+)/)[1];
+  }
+  return packageName;
+}
+
 export default config => {
   // pro 和 开发环境再添加这个插件
   if (process.env.APP_TYPE === 'site' || process.env.NODE_ENV !== 'production') {
@@ -30,4 +48,35 @@ export default config => {
       },
     ]);
   }
+  // optimize chunks
+  config.optimization
+    .runtimeChunk(false) // share the same chunks across different modules
+    .splitChunks({
+      chunks: 'all',
+      name: 'vendors',
+      maxInitialRequests: Infinity,
+      minSize: 0,
+      cacheGroups: {
+        vendors: {
+          test: (module, chunk) => {
+            const packageName = getModulePackageName(module);
+            if (packageName) {
+              return packageName in ['bizcharts', '@antv_data-set', '@ant-design_icons'];
+            }
+            return false;
+          },
+          name(module) {
+            const packageName = getModulePackageName(module);
+
+            if (packageName in ['bizcharts', '@antv_data-set']) {
+              return 'viz'; // visualization package
+            }
+            if (packageName in ['@ant-design_icons']) {
+              return 'icons';
+            }
+            return 'misc';
+          },
+        },
+      },
+    });
 };

--- a/config/plugin.config.js
+++ b/config/plugin.config.js
@@ -17,6 +17,7 @@ function getModulePackageName(module) {
   let packageName = moduleDirName;
   // handle tree shaking
   if (packageName.match('^_')) {
+    // eslint-disable-next-line prefer-destructuring
     packageName = packageName.match(/^_(@?[^@]+)/)[1];
   }
   return packageName;
@@ -58,20 +59,20 @@ export default config => {
       minSize: 0,
       cacheGroups: {
         vendors: {
-          test: (module, chunk) => {
+          test: module => {
             const packageName = getModulePackageName(module);
             if (packageName) {
-              return packageName in ['bizcharts', '@antv_data-set', '@ant-design_icons'];
+              return ['bizcharts', '@antv_data-set', '@ant-design_icons'].indexOf(packageName) >= 0;
             }
             return false;
           },
           name(module) {
             const packageName = getModulePackageName(module);
 
-            if (packageName in ['bizcharts', '@antv_data-set']) {
+            if (['bizcharts', '@antv_data-set'].indexOf(packageName) >= 0) {
               return 'viz'; // visualization package
             }
-            if (packageName in ['@ant-design_icons']) {
+            if (packageName === '@ant-design_icons') {
               return 'icons';
             }
             return 'misc';


### PR DESCRIPTION
https://github.com/ant-design/ant-design-pro/issues/3649
现有的解决包太大的问题的方法是把资源依赖移到了外面去了（用到了阿里的CDN）。某种程度上不是好选择，因为这样整个项目多了一个奇怪的依赖，如果没有互联网都没办法开发。而且还会需要单独设置csp来对付两个站外文件。
以下的代码如果进了“plugin.config.js”后会把相应的package或者sub package移到单独的文件。我根据现有的analyze，根据文件大小和相互之间的逻辑关联度，手动做了一个分类。虽然这样做不能减少包的总大小，但是有助于让不太经常需要的包单独成chunk（例如dataset和bizchart这种，会在带图标的页面异步加载）。

https://github.com/ant-design/ant-design-pro/pull/3650/files
现有版本（两个站外文件）：
![image](https://user-images.githubusercontent.com/1766793/53698640-97e5c380-3e1a-11e9-9f49-04606c03cf92.png)
现有版本（把站外文件拿回来）：
![image](https://user-images.githubusercontent.com/1766793/53698661-d8ddd800-3e1a-11e9-9d53-e95baaa1d88e.png)
按建议分块：
![image](https://user-images.githubusercontent.com/1766793/53710960-c7c4b380-3e7a-11e9-9541-0b7e946337d8.png)


总结：这个变化的核心思想是：
1. 把两个外链干掉，使用纯正的npm封装和依赖。
2. 把很多时候不一定要用到的包移到单独的chunk里面进行异步加载。
3. 建立一个可以给未来使用的chunk封装方法。

比较一下几个方案

|                          | umi.js   | vendors.js | total  | external |
|--------------------------|----------|------------|--------|----------|
| Current                  | 1.23MB   | 876.4KB    | 2.34MB | 2 files  |
| Current without External | 1.23MB   | 1.91MB     | 3.39MB | 0        |
| Proposed                 | 1.23MB | 767.01KB   | 3.39MB | 0        |

ref:
https://hackernoon.com/the-100-correct-way-to-split-your-chunks-with-webpack-f8a9df5b7758
https://webpack.js.org/plugins/split-chunks-plugin/

TODO:
- [ ] 把相关chunk改成lazy load的模式