### PR TITLE
Fix style error of DescriptionList following DescriptionList

### DIFF
--- a/src/components/DescriptionList/index.less
+++ b/src/components/DescriptionList/index.less
@@ -8,6 +8,14 @@
       overflow: hidden;
     }
   }
+  // fix margin top error of following descriptionList
+  & + & {
+    :global {
+      .ant-row {
+        margin-top: 16px;
+      }
+    }
+  }
 
   .title {
     margin-bottom: 16px;
@@ -45,6 +53,14 @@
     :global {
       .ant-row {
         margin-bottom: -8px;
+      }
+    }
+    // fix margin top error of following descriptionList
+    & + .descriptionList {
+      :global {
+        .ant-row {
+          margin-top: 8px;
+        }
       }
     }
     .title {


### PR DESCRIPTION
The text in a Description item could be wrapped when it's long enough causing DescriptionList style messes up. In this case using several DescriptionList one after one will be a solution. 

This pull request will fix the margin top error on the DescriptionList when it's following another DescriptionList.