### PR TITLE
Fix authoriy inherit issue

### DIFF
--- a/src/pages/Authorized.js
+++ b/src/pages/Authorized.js
@@ -6,21 +6,16 @@ import Authorized from '@/utils/Authorized';
 
 function AuthComponent({ children, location, routerData, status }) {
   const isLogin = status === 'ok';
-
   const getRouteAuthority = (path, routeData) => {
     let authorities;
     routeData.forEach(route => {
       // match prefix
       if (pathToRegexp(`${route.path}(.*)`).test(path)) {
-        if (route.authority) {
-          authorities = route.authority;
-        }
+        authorities = route.authority || authorities;
+
         // get children authority recursively
         if (route.routes) {
-          const auths = getRouteAuthority(path, route.routes);
-          if (auths) {
-            authorities = auths;
-          }
+          authorities = getRouteAuthority(path, route.routes) || authorities;
         }
       }
     });

--- a/src/pages/Authorized.js
+++ b/src/pages/Authorized.js
@@ -7,27 +7,24 @@ import Authorized from '@/utils/Authorized';
 function AuthComponent({ children, location, routerData, status }) {
   const isLogin = status === 'ok';
 
-  const getRouteAuthority = (pathname, routeData) => {
-    const routes = routeData.slice(); // clone
-
-    const getAuthority = (routeDatas, path) => {
-      let authorities;
-      routeDatas.forEach(route => {
-        // check partial route
-        if (pathToRegexp(`${route.path}(.*)`).test(path)) {
-          if (route.authority) {
-            authorities = route.authority;
-          }
-          // is exact route?
-          if (!pathToRegexp(route.path).test(path) && route.routes) {
-            authorities = getAuthority(route.routes, path);
+  const getRouteAuthority = (path, routeData) => {
+    let authorities;
+    routeData.forEach(route => {
+      // match prefix
+      if (pathToRegexp(`${route.path}(.*)`).test(path)) {
+        if (route.authority) {
+          authorities = route.authority;
+        }
+        // get children authority recursively
+        if (route.routes) {
+          const auths = getRouteAuthority(path, route.routes);
+          if (auths) {
+            authorities = auths;
           }
         }
-      });
-      return authorities;
-    };
-
-    return getAuthority(routes, pathname);
+      }
+    });
+    return authorities;
   };
   return (
     <Authorized


### PR DESCRIPTION
当前权限功能存在无法继承父权限的Bug。

eg: 对于下述权限配置，``/form/form1``无法继承到``/form``的``['admin', 'user']``权限，而返回的是undefined
```js
      {
        path: '/form',
        icon: 'form',
        name: 'form',
        authority: ['admin', 'user'],
        routes: [
          {
            path: '/form/form1',
            name: 'form1',
            component: './Forms/Form1',
          },
          {
            path: '/form/form2',
            name: 'advancedform',
            component: './Forms/Form2',
            authority: ['admin'],
          },
        ],
      },
```

其原因是``getRouteAuthority()``函数在递归返回的时候，未判断权限为空的情况。