### PR TITLE
fix:小屏幕显示不完全

### DIFF
--- a/src/components/TopNavHeader/index.js
+++ b/src/components/TopNavHeader/index.js
@@ -13,7 +13,11 @@ export default class TopNavHeader extends PureComponent {
 
   static getDerivedStateFromProps(props) {
     return {
-      maxWidth: (props.contentWidth === 'Fixed' && window.innerWidth > 1200 ? 1200 : window.innerWidth) - 280 - 165 - 40,
+      maxWidth:
+        (props.contentWidth === 'Fixed' && window.innerWidth > 1200 ? 1200 : window.innerWidth) -
+        280 -
+        120 -
+        40,
     };
   }
 

--- a/src/components/TopNavHeader/index.js
+++ b/src/components/TopNavHeader/index.js
@@ -13,7 +13,7 @@ export default class TopNavHeader extends PureComponent {
 
   static getDerivedStateFromProps(props) {
     return {
-      maxWidth: (props.contentWidth === 'Fixed' ? 1200 : window.innerWidth) - 280 - 165 - 40,
+      maxWidth: (props.contentWidth === 'Fixed' && window.innerWidth>1200 ? 1200 : window.innerWidth) - 280 - 165 - 40,
     };
   }
 

--- a/src/components/TopNavHeader/index.js
+++ b/src/components/TopNavHeader/index.js
@@ -13,7 +13,7 @@ export default class TopNavHeader extends PureComponent {
 
   static getDerivedStateFromProps(props) {
     return {
-      maxWidth: (props.contentWidth === 'Fixed' && window.innerWidth>1200 ? 1200 : window.innerWidth) - 280 - 165 - 40,
+      maxWidth: (props.contentWidth === 'Fixed' && window.innerWidth > 1200 ? 1200 : window.innerWidth) - 280 - 165 - 40,
     };
   }
 


### PR DESCRIPTION
"顶部菜单布局"且内容区域宽度为“定宽”时，若屏幕尺寸小于1200，顶部菜单右侧内容被遮挡。