### PR TITLE
Fix：pwa配置项

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -33,7 +33,7 @@ const plugins = [
               importWorkboxFrom: 'local',
             },
           }
-        : {},
+        : false,
       ...(!TEST && os.platform() === 'darwin'
         ? {
             dll: {


### PR DESCRIPTION
将./src/defaultSettings.js中pwa设置false时，‘umi-plugin-react’中pwa配置项的值应该是false；使用空对象{}依旧会开启 PWA 相关功能。