### PR TITLE
Optional prop which is used as label for Tooltip #3761

### DIFF
--- a/src/components/Charts/MiniProgress/index.d.ts
+++ b/src/components/Charts/MiniProgress/index.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 export interface IMiniProgressProps {
   target: number;
+  targetLabel: string;
   color?: string;
   strokeWidth?: number;
   percent?: number;

--- a/src/components/Charts/MiniProgress/index.js
+++ b/src/components/Charts/MiniProgress/index.js
@@ -1,11 +1,21 @@
 import React from 'react';
 import { Tooltip } from 'antd';
+import { formatMessage } from 'umi/locale';
 
 import styles from './index.less';
 
-const MiniProgress = ({ target, color = 'rgb(19, 194, 194)', strokeWidth, percent }) => (
+const MiniProgress = ({
+  targetLabel,
+  target,
+  color = 'rgb(19, 194, 194)',
+  strokeWidth,
+  percent,
+}) => (
   <div className={styles.miniProgress}>
-    <Tooltip title={`目标值: ${target}%`}>
+    <Tooltip
+      title={`${targetLabel ||
+        formatMessage({ id: 'component.miniProgress.tooltipDefault' }).concat(': ')} ${target}%`}
+    >
       <div className={styles.target} style={{ left: target ? `${target}%` : null }}>
         <span style={{ backgroundColor: color || null }} />
         <span style={{ backgroundColor: color || null }} />

--- a/src/locales/en-US/component.js
+++ b/src/locales/en-US/component.js
@@ -2,4 +2,5 @@ export default {
   'component.tagSelect.expand': 'Expand',
   'component.tagSelect.collapse': 'Collapse',
   'component.tagSelect.all': 'All',
+  'component.miniProgress.tooltipDefault': 'Target value',
 };

--- a/src/locales/pt-BR/component.js
+++ b/src/locales/pt-BR/component.js
@@ -2,4 +2,5 @@ export default {
   'component.tagSelect.expand': 'Expandir',
   'component.tagSelect.collapse': 'Diminuir',
   'component.tagSelect.all': 'Todas',
+  'component.miniProgress.tooltipDefault': 'Valor alvo',
 };

--- a/src/locales/zh-CN/component.js
+++ b/src/locales/zh-CN/component.js
@@ -2,4 +2,5 @@ export default {
   'component.tagSelect.expand': '展开',
   'component.tagSelect.collapse': '收起',
   'component.tagSelect.all': '全部',
+  'component.miniProgress.tooltipDefault': '目标值',
 };

--- a/src/locales/zh-TW/component.js
+++ b/src/locales/zh-TW/component.js
@@ -2,4 +2,5 @@ export default {
   'component.tagSelect.expand': '展開',
   'component.tagSelect.collapse': '收起',
   'component.tagSelect.all': '全部',
+  'component.miniProgress.tooltipDefault': '目标值',
 };


### PR DESCRIPTION
An _optional_ property for the component **MiniProgress** which will be used as the label for the **Tooltip**. In case of the value of the _prop_ isn't defined, a default _internationalized_ message will be used.
Those modifications were planned based on the issue [Can't Remove MiniProgress tooltip #3761 ](https://github.com/ant-design/ant-design-pro/issues/3761).