### PR TITLE
Eslint ignore lambda

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,3 @@
-/lambda
+/lambda/mock/**
 /scripts
 /config

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,3 @@
-/lambda/mock/**
+/lambda
 /scripts
 /config


### PR DESCRIPTION
主分支上面不会跑 `lambda/api.js` 不会eslint错误。
 Conventional-Routing 分支上面，会eslint错误。
lambda目录下的应该都被忽略，所以加了这个