### PR TITLE
Dynamic custom breadcrumb names

### DIFF
--- a/src/components/PageHeaderWrapper/breadcrumb.js
+++ b/src/components/PageHeaderWrapper/breadcrumb.js
@@ -16,6 +16,9 @@ const itemRender = (route, params, routes, paths) => {
 };
 
 const renderItemLocal = item => {
+  if (item.customBreadcrumbName) {
+    return item.customBreadcrumbName;
+  }
   if (item.locale) {
     return formatMessage({ id: item.locale, defaultMessage: item.name });
   }
@@ -87,12 +90,29 @@ const conversionFromLocation = (routerLocation, breadcrumbNameMap, props) => {
   return extraBreadcrumbItems;
 };
 
+const overrideBreadcrumbName = (breadcrumbNameMap, overrideMap) => {
+  if (!overrideMap) {
+    return breadcrumbNameMap;
+  }
+
+  return Object.keys(overrideMap).reduce(
+    (accum, key) => ({
+      ...accum,
+      [key]: {
+        ...accum[key],
+        customBreadcrumbName: overrideMap[key],
+      },
+    }),
+    breadcrumbNameMap
+  );
+};
+
 /**
  * 将参数转化为面包屑
  * Convert parameters into breadcrumbs
  */
 export const conversionBreadcrumbList = props => {
-  const { breadcrumbList } = props;
+  const { breadcrumbList, overrideBreadcrumbNameMap } = props;
   const { routes, params, routerLocation, breadcrumbNameMap } = getBreadcrumbProps(props);
   if (breadcrumbList && breadcrumbList.length) {
     return {
@@ -114,7 +134,11 @@ export const conversionBreadcrumbList = props => {
   // Generate breadcrumbs based on location
   if (routerLocation && routerLocation.pathname) {
     return {
-      routes: conversionFromLocation(routerLocation, breadcrumbNameMap, props),
+      routes: conversionFromLocation(
+        routerLocation,
+        overrideBreadcrumbName(breadcrumbNameMap, overrideBreadcrumbNameMap),
+        props
+      ),
       itemRender,
     };
   }


### PR DESCRIPTION
Allow override breadcrumb names. Useful when the route name is based on some model.

Exemples:
![Captura de Tela 2019-04-12 às 16 38 26](https://user-images.githubusercontent.com/1683922/56062227-1bf86880-5d42-11e9-9670-94db2304fcd1.png)
![Captura de Tela 2019-04-12 às 16 38 34](https://user-images.githubusercontent.com/1683922/56062266-36cadd00-5d42-11e9-9f8e-b8a3a2cfbd85.png)


![Captura de Tela 2019-04-12 às 16 37 13](https://user-images.githubusercontent.com/1683922/56062281-3d595480-5d42-11e9-8e4c-b8f753f278c9.png)
![Captura de Tela 2019-04-12 às 16 37 44](https://user-images.githubusercontent.com/1683922/56062286-3f231800-5d42-11e9-9b47-352bdb0ea440.png)
