### PR TITLE
add source map in site

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -70,6 +70,7 @@ export default {
   targets: {
     ie: 11,
   },
+  devtool: ANT_DESIGN_PRO_ONLY_DO_NOT_USE_IN_YOUR_PRODUCTION ? 'source-map' : false,
   // 路由配置
   routes: pageRoutes,
   // Theme for antd


### PR DESCRIPTION
官方的网站打开 sourcemap，方便定位一些编译之后的错误

The official website opens sourcemap, which is convenient for locating some errors after compilation.

