### PR TITLE
PageHeaderWrapper: fixed width, logo and home 

### DIFF
--- a/src/components/PageHeaderWrapper/index.js
+++ b/src/components/PageHeaderWrapper/index.js
@@ -38,6 +38,7 @@ const renderFooter = ({ tabList, tabActiveKey, onTabChange, tabBarExtraContent }
 const PageHeaderWrapper = ({
   children,
   contentWidth,
+  fluid,
   wrapperClassName,
   top,
   title,
@@ -53,42 +54,50 @@ const PageHeaderWrapper = ({
       <MenuContext.Consumer>
         {value => {
           return (
-            <PageHeader
-              wide={contentWidth === 'Fixed'}
-              title={
-                <Title
-                  level={4}
-                  style={{
-                    marginBottom: 0,
-                  }}
+            <div className={styles.wrapper}>
+              <div
+                className={classNames({
+                  [styles.wide]: !fluid && contentWidth === 'Fixed',
+                })}
+              >
+                <PageHeader
+                  wide={contentWidth === 'Fixed'}
+                  title={
+                    <Title
+                      level={4}
+                      style={{
+                        marginBottom: 0,
+                      }}
+                    >
+                      {title}
+                    </Title>
+                  }
+                  key="pageheader"
+                  {...restProps}
+                  breadcrumb={
+                    !hiddenBreadcrumb &&
+                    conversionBreadcrumbList({
+                      ...value,
+                      ...restProps,
+                      home: <FormattedMessage id="menu.home" defaultMessage="Home" />,
+                    })
+                  }
+                  className={styles.pageHeader}
+                  linkElement={Link}
+                  footer={renderFooter(restProps)}
                 >
-                  {title}
-                </Title>
-              }
-              key="pageheader"
-              {...restProps}
-              breadcrumb={
-                !hiddenBreadcrumb &&
-                conversionBreadcrumbList({
-                  ...value,
-                  ...restProps,
-                  home: <FormattedMessage id="menu.home" defaultMessage="Home" />,
-                })
-              }
-              className={styles.pageHeader}
-              linkElement={Link}
-              footer={renderFooter(restProps)}
-            >
-              <div className={styles.detail}>
-                {logo && <div className={styles.logo}>{logo}</div>}
-                <div className={styles.main}>
-                  <div className={styles.row}>
-                    {content && <div className={styles.content}>{content}</div>}
-                    {extraContent && <div className={styles.extraContent}>{extraContent}</div>}
+                  <div className={styles.detail}>
+                    {logo && <div className={styles.logo}>{logo}</div>}
+                    <div className={styles.main}>
+                      <div className={styles.row}>
+                        {content && <div className={styles.content}>{content}</div>}
+                        {extraContent && <div className={styles.extraContent}>{extraContent}</div>}
+                      </div>
+                    </div>
                   </div>
-                </div>
+                </PageHeader>
               </div>
-            </PageHeader>
+            </div>
           );
         }}
       </MenuContext.Consumer>

--- a/src/components/PageHeaderWrapper/index.js
+++ b/src/components/PageHeaderWrapper/index.js
@@ -61,16 +61,19 @@ const PageHeaderWrapper = ({
                 })}
               >
                 <PageHeader
-                  wide={contentWidth === 'Fixed'}
                   title={
-                    <Title
-                      level={4}
-                      style={{
-                        marginBottom: 0,
-                      }}
-                    >
-                      {title}
-                    </Title>
+                    <>
+                      {logo && <span className={styles.logo}>{logo}</span>}
+                      <Title
+                        level={4}
+                        style={{
+                          marginBottom: 0,
+                          display: 'inline-block',
+                        }}
+                      >
+                        {title}
+                      </Title>
+                    </>
                   }
                   key="pageheader"
                   {...restProps}
@@ -87,7 +90,6 @@ const PageHeaderWrapper = ({
                   footer={renderFooter(restProps)}
                 >
                   <div className={styles.detail}>
-                    {logo && <div className={styles.logo}>{logo}</div>}
                     <div className={styles.main}>
                       <div className={styles.row}>
                         {content && <div className={styles.content}>{content}</div>}

--- a/src/components/PageHeaderWrapper/index.js
+++ b/src/components/PageHeaderWrapper/index.js
@@ -40,6 +40,7 @@ const PageHeaderWrapper = ({
   contentWidth,
   fluid,
   wrapperClassName,
+  home,
   top,
   title,
   content,
@@ -82,7 +83,9 @@ const PageHeaderWrapper = ({
                     conversionBreadcrumbList({
                       ...value,
                       ...restProps,
-                      home: <FormattedMessage id="menu.home" defaultMessage="Home" />,
+                      ...(home !== null && {
+                        home: <FormattedMessage id="menu.home" defaultMessage="Home" />,
+                      }),
                     })
                   }
                   className={styles.pageHeader}

--- a/src/components/PageHeaderWrapper/index.less
+++ b/src/components/PageHeaderWrapper/index.less
@@ -16,6 +16,7 @@
       }
 
       .ant-page-header-title-view-extra {
+        top: 0;
         right: 0;
       }
     }

--- a/src/components/PageHeaderWrapper/index.less
+++ b/src/components/PageHeaderWrapper/index.less
@@ -35,9 +35,10 @@
   }
 
   .logo {
-    flex: 0 1 auto;
+    display: inline-block;
+    margin-top: -1px;
     margin-right: 16px;
-    padding-top: 1px;
+    vertical-align: middle;
     > img {
       display: block;
       width: 28px;
@@ -74,7 +75,6 @@
     margin-bottom: 16px;
   }
 
-  .logo,
   .content,
   .extraContent {
     margin-bottom: 16px;

--- a/src/components/PageHeaderWrapper/index.less
+++ b/src/components/PageHeaderWrapper/index.less
@@ -5,11 +5,19 @@
 }
 
 .main {
-  :global {
-    .ant-page-header {
-      padding: 16px 32px 0;
-      background: #fff;
-      border-bottom: 1px solid #e8e8e8;
+  .wrapper {
+    padding: 16px 24px 0;
+    background: #fff;
+    border-bottom: 1px solid #e8e8e8;
+
+    :global {
+      .ant-page-header {
+        padding: 0;
+      }
+
+      .ant-page-header-title-view-extra {
+        right: 0;
+      }
     }
   }
 


### PR DESCRIPTION
- PageHeaderWrapper width adjusted by contentWidth
- new fluid prop to make PageHeaderWrapper fluid independently of contentWidth
- logo side by side with title
- home={null} working again