### PR TITLE
fix #4311 lint error in windows

### DIFF
--- a/create-umi/package.json
+++ b/create-umi/package.json
@@ -13,7 +13,7 @@
     "lint:fix": "eslint --fix --ext .js src tests && npm run lint:style && npm run tslint:fix",
     "lint:js": "eslint --ext .js src tests",
     "lint:prettier": "check-prettier lint",
-    "lint:style": "stylelint --fix 'src/**/*.less' --syntax less",
+    "lint:style": "stylelint --fix \"src/**/*.less\" --syntax less",
     "lint:ts": "tslint -p . -c tslint.yml",
     "prettier": " check-prettier write",
     "start": "umi dev",
@@ -21,7 +21,7 @@
     "test": "umi test",
     "test:all": "node ./tests/run-tests.js",
     "test:component": "umi test ./src/components",
-    "tslint:fix": "tslint --fix 'src/**/*.ts*'",
+    "tslint:fix": "tslint --fix \"src/**/*.ts*\"",
     "fetch:blocks": "node ./scripts/fetch-blocks.js"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint:fix": "eslint --fix --ext .js src tests && npm run lint:style && npm run tslint:fix",
     "lint:js": "eslint --ext .js src tests",
     "lint:prettier": "check-prettier lint",
-    "lint:style": "stylelint --fix 'src/**/*.less' --syntax less",
+    "lint:style": "stylelint --fix \"src/**/*.less\" --syntax less",
     "lint:ts": "tslint -p . -c tslint.yml",
     "prettier": " check-prettier write",
     "site": "npm run fetch:blocks && npm run functions:build && umi build",
@@ -33,7 +33,7 @@
     "test": "umi test",
     "test:all": "node ./tests/run-tests.js",
     "test:component": "umi test ./src/components",
-    "tslint:fix": "tslint --fix 'src/**/*.ts*'"
+    "tslint:fix": "tslint --fix \"src/**/*.ts*\""
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
cmd不支持单引号，改为双引号即可。