### PR TITLE
translate 'dashboard' copywriting in menu

### DIFF
--- a/src/locales/zh-CN/menu.ts
+++ b/src/locales/zh-CN/menu.ts
@@ -5,7 +5,7 @@ export default {
   'menu.login': '登录',
   'menu.register': '注册',
   'menu.register.result': '注册结果',
-  'menu.dashboard': 'Dashboard',
+  'menu.dashboard': '仪表板',
   'menu.dashboard.analysis': '分析页',
   'menu.dashboard.monitor': '监控页',
   'menu.dashboard.workplace': '工作台',

--- a/src/locales/zh-TW/menu.ts
+++ b/src/locales/zh-TW/menu.ts
@@ -9,7 +9,7 @@ export default {
   'menu.exception.500': '500',
   'menu.register': '註冊',
   'menu.register.resultt': '註冊結果',
-  'menu.dashboard': 'Dashboard',
+  'menu.dashboard': '儀表板',
   'menu.dashboard.analysis': '分析頁',
   'menu.dashboard.monitor': '監控頁',
   'menu.dashboard.workplace': '工作臺',


### PR DESCRIPTION
Translate 'Dashboard' to '仪表板‘ in zh-CN locales.