### PR TITLE
修复二级菜单设置权限时报错问题。

### DIFF
--- a/src/layouts/BasicLayout.tsx
+++ b/src/layouts/BasicLayout.tsx
@@ -37,7 +37,7 @@ export type BasicLayoutContext = { [K in 'location']: BasicLayoutProps[K] } & {
 const menuDataRender = (menuList: MenuDataItem[]): MenuDataItem[] => {
   return menuList.map(item => {
     const localItem = { ...item, children: item.children ? menuDataRender(item.children) : [] };
-    return Authorized.check(item.authority, localItem, null) as MenuDataItem;
+    return Authorized.check(item.authority, localItem, {}) as MenuDataItem;
   });
 };
 


### PR DESCRIPTION
Authorized.check(item.authority, localItem, null)会导致渲染菜单时```Uncaught TypeError:Cannot read property 'name' of null错误。目前解决办法是替换成{}