### PR TITLE
修复plugin.config.ts小问题

### DIFF
--- a/config/plugin.config.ts
+++ b/config/plugin.config.ts
@@ -107,7 +107,7 @@ const getAntdSerials = (color: string) => {
   const lightNum = 9;
   const devide10 = 10;
   // 淡化（即less的tint）
-  const lightens = new Array(lightNum).fill().map((t, i) => {
+  const lightens = new Array(lightNum).fill({}).map((t: any, i: number) => {
     return ThemeColorReplacer.varyColor.lighten(color, i / devide10);
   });
   const colorPalettes = generate(color);


### PR DESCRIPTION
Array.prototype.fill(value[, start[, end]])
value是必须要传递的本地一直显示错误，还有后面的两个参数指定数据类型，都是些小问题...
