### PR TITLE
fix: paths of same prefix problem.

### DIFF
--- a/src/pages/Authorized.tsx
+++ b/src/pages/Authorized.tsx
@@ -14,7 +14,10 @@ const getRouteAuthority = (path: string, routeData: Route[]) => {
   routeData.forEach(route => {
     // match prefix
     if (pathToRegexp(`${route.path}(.*)`).test(path)) {
-      authorities = route.authority || authorities;
+      // exact match
+      if (route.path === path) {
+        authorities = route.authority || authorities;
+      }
       // get children authority recursively
       if (route.routes) {
         authorities = getRouteAuthority(path, route.routes) || authorities;


### PR DESCRIPTION
Paths of same prefix will return the last match. It will occurs problem as follows:
Routes:
```{
  path: '/',
  authority: ['admin', 'user']
  routes: [
	{
	  path: '/prefix2',
      authority: ['user']
	},
	{
	  path: '/prefix',
      authority: ['admin']
	},
  ]
}
```
Problem：
When user visit the '/prefix2', it will match the '/prefix', then Exception403 occurs.