### PR TITLE
modify docker-hub:build

### DIFF
--- a/Dockerfile.hub
+++ b/Dockerfile.hub
@@ -1,10 +1,24 @@
-FROM nginx
+FROM circleci/node:latest-browsers as builder
 
 WORKDIR /usr/src/app/
+USER root
+COPY package.json ./
+RUN yarn
+
+COPY ./ ./
+
+RUN npm run test:all
+
+RUN npm run build
+
+
+FROM nginx
+
+WORKDIR /usr/share/nginx/html/
 
 COPY ./docker/nginx.conf /etc/nginx/conf.d/default.conf
 
-COPY ./dist  /usr/share/nginx/html/
+COPY --from=builder /usr/src/app/dist  /usr/share/nginx/html/
 
 EXPOSE 80
 


### PR DESCRIPTION
docker-hub在构建镜像之前需要依赖项目已经打包到dist目录，否则报错