### PR TITLE
Fix vscode lint in v8.6.0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,9 +1,8 @@
 const { strictEslint } = require('@umijs/fabric');
 
-module.exports = {
-  ...strictEslint,
+module.exports = Object.assign({}, strictEslint, {
   globals: {
     ANT_DESIGN_PRO_ONLY_DO_NOT_USE_IN_YOUR_PRODUCTION: true,
     page: true,
   },
-};
+});

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,5 +1,3 @@
 const fabric = require('@umijs/fabric');
 
-module.exports = {
-  ...fabric.prettier,
-};
+module.exports = Object.assign({}, fabric.prettier);

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,5 +1,3 @@
 const fabric = require('@umijs/fabric');
 
-module.exports = {
-  ...fabric.stylelint,
-};
+module.exports = Object.assign({}, fabric.stylelint);


### PR DESCRIPTION
lint should be compatible with different node versions

![image](https://user-images.githubusercontent.com/13595509/60391355-28a98300-9b1f-11e9-99b3-9ff542effae1.png)

refer Microsoft/vscode-eslint#345
