### PR TITLE
fix: fix NoticeIcon dev warning

### DIFF
--- a/src/components/NoticeIcon/index.tsx
+++ b/src/components/NoticeIcon/index.tsx
@@ -117,11 +117,13 @@ export default class NoticeIcon extends Component<NoticeIconProps> {
       },
     );
     return (
-      <Spin spinning={loading} delay={300}>
-        <Tabs className={styles.tabs} onChange={this.onTabChange}>
-          {panes}
-        </Tabs>
-      </Spin>
+      <>
+        <Spin spinning={loading} delay={300}>
+          <Tabs className={styles.tabs} onChange={this.onTabChange}>
+            {panes}
+          </Tabs>
+        </Spin>
+      </>
     );
   }
 
@@ -155,6 +157,7 @@ export default class NoticeIcon extends Component<NoticeIconProps> {
     if ('popupVisible' in this.props) {
       popoverProps.visible = popupVisible;
     }
+
     return (
       <HeaderDropdown
         placement="bottomRight"


### PR DESCRIPTION
antd 会给 overlay 中的 node 注入一些 props。spin 会原封不动的继承。然后渲染在 dom 上。但其实是不需要的

close https://github.com/ant-design/ant-design-pro/issues/4658

https://github.com/ant-design/ant-design/blob/65eb713fe897f65bbf187e215c664e5f9b468252/components/dropdown/dropdown.tsx#L109