### PR TITLE
fix: lint:js path

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint-staged": "lint-staged",
     "lint-staged:js": "eslint --ext .js,.jsx,.ts,.tsx ",
     "lint:fix": "eslint --fix --cache --ext .js,.jsx,.ts,.tsx --format=pretty ./src && npm run lint:style",
-    "lint:js": "eslint --cache --ext .js,.jsx,.ts,.tsx --format=pretty ./src",
+    "lint:js": "eslint --cache --ext .js,.jsx,.ts,.tsx --format=pretty ./",
     "lint:prettier": "check-prettier lint",
     "lint:style": "stylelint --fix \"src/**/*.less\" --syntax less",
     "prettier": "prettier -c --write \"**/*\"",


### PR DESCRIPTION
package中配置为
"lint:js": "eslint --cache --ext .js,.jsx,.ts,.tsx --format=pretty ./src",
所以src以外报错是没有提示的，然后提交也提交不了。
修改为
"lint:js": "eslint --cache --ext .js,.jsx,.ts,.tsx --format=pretty ./",
能够看到错误，修改后正常提交
close #4720 