### PR TITLE
check route.path for trailing '/'

### DIFF
--- a/src/pages/Authorized.tsx
+++ b/src/pages/Authorized.tsx
@@ -15,7 +15,7 @@ const getRouteAuthority = (path: string, routeData: Route[]) => {
     // match prefix
     if (pathToRegexp(`${route.path}(.*)`).test(path)) {
       // exact match
-      if (route.path === path) {
+      if ((route.path === path || route.path + '/' === path) {
         authorities = route.authority || authorities;
       }
       // get children authority recursively


### PR DESCRIPTION
Current getRouteAuthority() function doesn't check for trailing '/' in order to find authorities returning undefined if the url has a trailing '/' - enabling access to the page even if not authorised.