### PR TITLE
修复GlobalHeader中RightContent样式问题

### DIFF
--- a/src/components/GlobalHeader/index.less
+++ b/src/components/GlobalHeader/index.less
@@ -91,6 +91,23 @@
   }
 }
 
+:global(.ant-pro-global-header) {
+  .dark {
+    .action {
+      color: @text-color;
+      > i {
+        color: @text-color;
+      }
+      &:hover {
+        color: rgba(255, 255, 255, 0.85);
+        > i {
+          color: rgba(255, 255, 255, 0.85);
+        }
+      }
+    }
+  }
+}
+
 @media only screen and (max-width: @screen-md) {
   :global(.ant-divider-vertical) {
     vertical-align: unset;

--- a/src/components/GlobalHeader/index.less
+++ b/src/components/GlobalHeader/index.less
@@ -110,7 +110,6 @@
     position: absolute;
     top: 0;
     right: 12px;
-    background: #fff;
     .account {
       .avatar {
         margin-right: 0;


### PR DESCRIPTION
修改`GlobalHeader`中`RightContent`在`dark`和`topmenu`模式下, 

`@media only screen and (max-width: @screen-md)`( 注:`768px`)的样式错误

[官方演示demo](https://preview.pro.ant.design/dashboard/analysis?language=zh-CN&layout=topmenu&contentWidth=Fixed)

![image](https://user-images.githubusercontent.com/13941674/63883737-659ed280-ca07-11e9-9812-fbf5a5cb5532.png)
