### PR TITLE
fix: 通过create umi创建项目可能不需要CNAME

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
       "README.*.md",
       "azure-pipelines.yml",
       "docker",
+      "CNAME",
       "create-umi"
     ]
   }


### PR DESCRIPTION
使用create umi建立项目不需要CNAME文件
close #5205 