### PR TITLE
optimize SecurityLayout

### DIFF
--- a/src/layouts/SecurityLayout.tsx
+++ b/src/layouts/SecurityLayout.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'dva';
 import { Redirect } from 'umi';
+import { stringify } from 'querystring';
 import { ConnectState, ConnectProps } from '@/models/connect';
 import { CurrentUser } from '@/models/user';
 import PageLoading from '@/components/PageLoading';
@@ -34,11 +35,18 @@ class SecurityLayout extends React.Component<SecurityLayoutProps, SecurityLayout
   render() {
     const { isReady } = this.state;
     const { children, loading, currentUser } = this.props;
-    if ((!currentUser.userid && loading) || !isReady) {
+    // You can replace it to your authentication rule (such as check token exists)
+    // 你可以把它替换成你自己的登录认证规则（比如判断 token 是否存在）
+    const isLogin = currentUser && currentUser.userid;
+    const queryString = stringify({
+      redirect: window.location.href,
+    });
+
+    if ((!isLogin && loading) || !isReady) {
       return <PageLoading />;
     }
-    if (!currentUser.userid) {
-      return <Redirect to="/user/login"></Redirect>;
+    if (!isLogin) {
+      return <Redirect to={`/user/login?${queryString}`}></Redirect>;
     }
     return children;
   }


### PR DESCRIPTION
项目里想要实现基于 JWT 的鉴权功能，当 token 没有时跳转到登录页，发现最新的代码里面已经添加了 SecurityLayout 去实现该功能，觉得很不错，优化了一下能够实现登录后重定向到之前访问的页面。

1. 添加了 redirect query string
2. 将判断是否登录用 isLogin 变量保存并添加注释     

![QQ截图20190912145513](https://user-images.githubusercontent.com/16114101/64761310-5fb00200-d56e-11e9-9b6d-e8f198b1feda.png)


