### PR TITLE
fix: GlobalHeader styles

### DIFF
--- a/src/components/GlobalHeader/index.less
+++ b/src/components/GlobalHeader/index.less
@@ -85,9 +85,6 @@
     &:global(.opened) {
       background: @primary-color;
     }
-    :global(.ant-badge) {
-      color: rgba(255, 255, 255, 0.85);
-    }
   }
 }
 


### PR DESCRIPTION
在 `@media only screen and (max-width: 768px)` 分辨率下，消息 `icon` 的颜色与背景色冲突

![image](https://user-images.githubusercontent.com/21023676/64762657-21681200-d571-11e9-964c-d96e85e98406.png)


**重现步骤：**
- 手机模式下打开官方演示网站
- 设置中选择 `暗色菜单风格` & `顶部菜单布局`

close https://github.com/ant-design/ant-design-pro/issues/5192