### PR TITLE
解决主题色替换导致的样式覆盖问题。

### DIFF
--- a/config/plugin.config.ts
+++ b/config/plugin.config.ts
@@ -5,6 +5,10 @@ import ThemeColorReplacer from 'webpack-theme-color-replacer';
 import generate from '@ant-design/colors/lib/generate';
 import path from 'path';
 
+interface SelectorUtil {
+  changeEach(selector: string, surfix: string, prefix?: string): string;
+}
+
 function getModulePackageName(module: { context: string }) {
   if (!module.context) return null;
 
@@ -34,15 +38,35 @@ export default (config: any) => {
       {
         fileName: 'css/theme-colors-[contenthash:8].css',
         matchColors: getAntdSerials('#1890ff'), // 主色系列
-        // 改变样式选择器，解决样式覆盖问题
-        changeSelector(selector: string): string {
+        // 改变样式选择器，解决样式覆盖问题(最好能通过修改antd解决)
+        changeSelector(selector: string, util: SelectorUtil): string {
           switch (selector) {
             case '.ant-calendar-today .ant-calendar-date':
-              return ':not(.ant-calendar-selected-date)' + selector;
+              return ':not(.ant-calendar-selected-date):not(.ant-calendar-selected-day)' + selector;
             case '.ant-btn:focus,.ant-btn:hover':
-              return '.ant-btn:focus:not(.ant-btn-primary),.ant-btn:hover:not(.ant-btn-primary)';
+              return util.changeEach(selector, ':not(.ant-btn-primary):not(.ant-btn-danger)');
             case '.ant-btn.active,.ant-btn:active':
-              return '.ant-btn.active:not(.ant-btn-primary),.ant-btn:active:not(.ant-btn-primary)';
+              return util.changeEach(selector, ':not(.ant-btn-primary):not(.ant-btn-danger)');
+            case '.ant-steps-item-process .ant-steps-item-icon>.ant-steps-icon':
+              return ':not(.ant-steps-item-process)' + selector;
+            case '.ant-menu-horizontal>.ant-menu-item-active,.ant-menu-horizontal>.ant-menu-item-open,' +
+              '.ant-menu-horizontal>.ant-menu-item-selected,.ant-menu-horizontal>.ant-menu-item:hover,' +
+              '.ant-menu-horizontal>.ant-menu-submenu-active,.ant-menu-horizontal>.ant-menu-submenu-open,' +
+              '.ant-menu-horizontal>.ant-menu-submenu-selected,.ant-menu-horizontal>.ant-menu-submenu:hover':
+              return (
+                '.ant-menu-horizontal>.ant-menu-item-active,' +
+                '.ant-menu-horizontal>.ant-menu-item-open,' +
+                '.ant-menu-horizontal>.ant-menu-item-selected,' +
+                '.ant-menu-horizontal:not(.ant-menu-dark)>.ant-menu-item:hover,' +
+                '.ant-menu-horizontal>.ant-menu-submenu-active,' +
+                '.ant-menu-horizontal>.ant-menu-submenu-open,' +
+                '.ant-menu-horizontal:not(.ant-menu-dark)>.ant-menu-submenu-selected,' +
+                '.ant-menu-horizontal:not(.ant-menu-dark)>.ant-menu-submenu:hover'
+              );
+            case '.ant-menu-horizontal>.ant-menu-item-selected>a':
+              return '.ant-menu-horizontal:not(ant-menu-light):not(.ant-menu-dark)>.ant-menu-item-selected>a';
+            case '.ant-menu-horizontal>.ant-menu-item>a:hover':
+              return '.ant-menu-horizontal:not(ant-menu-light):not(.ant-menu-dark)>.ant-menu-item>a:hover';
             default:
               return selector;
           }

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "umi-plugin-ga": "^1.1.3",
     "umi-plugin-pro": "^1.0.2",
     "umi-types": "^0.4.1",
-    "webpack-theme-color-replacer": "^1.2.15"
+    "webpack-theme-color-replacer": "^1.2.18"
   },
   "optionalDependencies": {
     "puppeteer": "^1.17.0"

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "umi-plugin-ga": "^1.1.3",
     "umi-plugin-pro": "^1.0.2",
     "umi-types": "^0.4.1",
-    "webpack-theme-color-replacer": "^1.2.18"
+    "webpack-theme-color-replacer": "^1.2.20"
   },
   "optionalDependencies": {
     "puppeteer": "^1.17.0"


### PR DESCRIPTION
 改变主题色替换时的样式选择器，解决主题色替换导致的样式覆盖问题。类似这种：
![image](https://user-images.githubusercontent.com/19581578/65589566-da8c0a80-dfbb-11e9-9794-e6267be8f374.png)

代码来源：https://github.com/sendya/ant-design-pro-vue

