### PR TITLE
fix: right-align the right content of topmenu

### DIFF
--- a/src/components/GlobalHeader/index.less
+++ b/src/components/GlobalHeader/index.less
@@ -39,6 +39,7 @@
 .right {
   float: right;
   height: 100%;
+  margin-left: auto;
   overflow: hidden;
   .action {
     display: inline-block;


### PR DESCRIPTION
topmenu 情况下，right content 作为 flex item，`float: right` 无效。设置 margin 来实现**靠右**