### PR TITLE
fix:rationalize dependencies and devDependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "not ie <= 10"
   ],
   "dependencies": {
+    "@ant-design/colors": "^3.1.0",
     "@ant-design/pro-layout": "^4.5.16",
     "@antv/data-set": "^0.10.2",
     "antd": "^3.23.6",
@@ -71,13 +72,14 @@
     "react-document-title": "^2.0.3",
     "react-dom": "^16.8.6",
     "redux": "^4.0.1",
+    "slash2": "^2.0.0",
     "umi": "^2.9.6",
     "umi-plugin-pro-block": "^1.3.4",
     "umi-plugin-react": "^1.10.1",
-    "umi-request": "^1.2.7"
+    "umi-request": "^1.2.7",
+    "webpack-theme-color-replacer": "^1.2.15"
   },
   "devDependencies": {
-    "@ant-design/colors": "^3.1.0",
     "@ant-design/pro-cli": "^1.0.13",
     "@types/classnames": "^2.2.7",
     "@types/express": "^4.17.0",
@@ -110,12 +112,10 @@
     "prettier": "^1.17.1",
     "pro-download": "1.0.1",
     "serverless-http": "^2.0.2",
-    "slash2": "^2.0.0",
     "stylelint": "^10.1.0",
     "umi-plugin-ga": "^1.1.3",
     "umi-plugin-pro": "^1.0.2",
-    "umi-types": "^0.5.0",
-    "webpack-theme-color-replacer": "^1.2.15"
+    "umi-types": "^0.5.0"
   },
   "optionalDependencies": {
     "puppeteer": "^1.17.0"


### PR DESCRIPTION
There are three packages are used in production environment but declared in devDependencies.
Now put them into dependencies. 

close #5410 