### PR TITLE
修改docker nginx配置

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -9,7 +9,7 @@ server {
     gzip_disable "MSIE [1-6]\.";
 
     root /usr/share/nginx/html;
-
+    include /etc/nginx/mime.types;
     location / {
         try_files $uri $uri/ /index.html;
     }


### PR DESCRIPTION
部署后css的content type为test/plain导致页面无法正常渲染css，需要修改nginx配置。