### PR TITLE
Use menuHeaderRender in ProLayout to render Link

### DIFF
--- a/src/layouts/BasicLayout.tsx
+++ b/src/layouts/BasicLayout.tsx
@@ -150,6 +150,12 @@ const BasicLayout: React.FC<BasicLayoutProps> = props => {
   return (
     <ProLayout
       logo={logo}
+      menuHeaderRender={(logoDom, titleDom) => (
+        <Link to="/">
+          {logoDom}
+          {titleDom}
+        </Link>
+      )}
       onCollapse={handleMenuCollapse}
       menuItemRender={(menuItemProps, defaultDom) => {
         if (menuItemProps.isUrl) {


### PR DESCRIPTION
Without `menuHeaderRender`, `ProLayout` would render a HTML anchor link using `<a href="..."></a>` consequently resulting in a page redirection when the user clicks the logo icon.

Therefore, this PR, which uses `menuHeaderRender` in `ProLayout` to render a `<Link>...</Link>` instead, avoids this page redirection and hence results in a better user experience.