### PR TITLE
doc: fix Use bash error.

### DIFF
--- a/README.fr-FR.md
+++ b/README.fr-FR.md
@@ -79,6 +79,8 @@ Nous avons besoin de votre aide: https://github.com/ant-design/ant-design-pro/is
 ### Utiliser bash
 
 ```bash
+$ mkdir <your-project-name>
+$ cd <your-project-name>
 $ yarn create umi  # or npm create umi
 
 # Choose ant-design-pro:
@@ -89,6 +91,7 @@ $ yarn create umi  # or npm create umi
   library         - Create a library with umi.
   plugin          - Create a umi plugin.
 
+$ git init
 $ npm install
 $ npm start         # visit http://localhost:8000
 ```

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -79,6 +79,8 @@
 ### bash を使う方法
 
 ```bash
+$ mkdir <your-project-name>
+$ cd <your-project-name>
 $ yarn create umi  # or npm create umi
 
 # Choose ant-design-pro:
@@ -89,6 +91,7 @@ $ yarn create umi  # or npm create umi
   library         - Create a library with umi.
   plugin          - Create a umi plugin.
 
+$ git init
 $ npm install
 $ npm start         # http://localhost:8000 を開く
 ```

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ We need your help: https://github.com/ant-design/ant-design-pro/issues/120
 ### Use bash
 
 ```bash
+$ mkdir <your-project-name>
+$ cd <your-project-name>
 $ yarn create umi  # or npm create umi
 
 # Choose ant-design-pro:
@@ -91,6 +93,7 @@ $ yarn create umi  # or npm create umi
   library         - Create a library with umi.
   plugin          - Create a umi plugin.
 
+$ git init
 $ npm install
 $ npm start         # visit http://localhost:8000
 ```

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -81,6 +81,8 @@ Precisamos da sua ajuda: https://github.com/ant-design/ant-design-pro/issues/120
 ### Use o bash
 
 ```bash
+$ mkdir <your-project-name>
+$ cd <your-project-name>
 $ yarn create umi  # ou npm create umi
 
 # Escolha ant-design-pro:
@@ -91,6 +93,7 @@ $ yarn create umi  # ou npm create umi
   library         - Create a library with umi.
   plugin          - Create a umi plugin.
 
+$ git init
 $ npm install
 $ npm start         # visit http://localhost:8000
 ```

--- a/README.ru-RU.md
+++ b/README.ru-RU.md
@@ -73,6 +73,8 @@ UI-решение "из коробки" для корпоративных при
 ## Использование
 
 ```bash
+$ mkdir <your-project-name>
+$ cd <your-project-name>
 $ yarn create umi  # or npm create umi
 
 # Choose ant-design-pro:
@@ -83,6 +85,7 @@ $ yarn create umi  # or npm create umi
   library         - Create a library with umi.
   plugin          - Create a umi plugin.
 
+$ git init
 $ npm install
 $ npm start         # visit http://localhost:8000
 ```

--- a/README.tr-TR.md
+++ b/README.tr-TR.md
@@ -81,6 +81,8 @@ React ile kurumsal uygulamalar için taslak olarak geliştirilmiş kullanıma ha
 ### Bash ile
 
 ```bash
+$ mkdir <your-project-name>
+$ cd <your-project-name>
 $ yarn create umi  # or npm create umi
 
 # Choose ant-design-pro:
@@ -91,6 +93,7 @@ $ yarn create umi  # or npm create umi
   library         - Create a library with umi.
   plugin          - Create a umi plugin.
 
+$ git init
 $ npm install
 $ npm start         # visit http://localhost:8000
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -75,6 +75,8 @@
 ## 使用
 
 ```bash
+$ mkdir <your-project-name>
+$ cd <your-project-name>
 $ yarn create umi  # or npm create umi
 
 # Choose ant-design-pro:
@@ -85,6 +87,7 @@ $ yarn create umi  # or npm create umi
   library         - Create a library with umi.
   plugin          - Create a umi plugin.
 
+$ git init
 $ npm install
 $ npm start         # visit http://localhost:8000
 ```


### PR DESCRIPTION
Use bash

1. 'npm create umi' needs to be run in an empty folder;
2. During the 'husky' installation, if it is not a git repository, an error will be reported, so run 'git init'.

-----
[View rendered README.fr-FR.md](https://github.com/forijk/ant-design-pro/blob/fix-doc-use-bash-error/README.fr-FR.md)
[View rendered README.ja-JP.md](https://github.com/forijk/ant-design-pro/blob/fix-doc-use-bash-error/README.ja-JP.md)
[View rendered README.md](https://github.com/forijk/ant-design-pro/blob/fix-doc-use-bash-error/README.md)
[View rendered README.pt-BR.md](https://github.com/forijk/ant-design-pro/blob/fix-doc-use-bash-error/README.pt-BR.md)
[View rendered README.ru-RU.md](https://github.com/forijk/ant-design-pro/blob/fix-doc-use-bash-error/README.ru-RU.md)
[View rendered README.tr-TR.md](https://github.com/forijk/ant-design-pro/blob/fix-doc-use-bash-error/README.tr-TR.md)
[View rendered README.zh-CN.md](https://github.com/forijk/ant-design-pro/blob/fix-doc-use-bash-error/README.zh-CN.md)