### PR TITLE
remove git add for lint-staged hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
   "lint-staged": {
     "**/*.less": "stylelint --syntax less",
     "**/*.{js,jsx,tsx,ts,less,md,json}": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ],
     "**/*.{js,jsx,ts,tsx}": "npm run lint-staged:js"
   },


### PR DESCRIPTION
#5907 

https://github.com/okonet/lint-staged/releases/tag/v10.0.0

Prior to version 10, tasks had to manually include git add as the final step. This behavior has been integrated into lint-staged itself in order to prevent race conditions with multiple tasks editing the same files. If lint-staged detects git add in task configurations, it will show a warning in the console. Please remove git add from your configuration after upgrading.