### PR TITLE
refactor: use umi 3

### DIFF
--- a/config/config.ts
+++ b/config/config.ts
@@ -1,64 +1,14 @@
-import { IConfig, IPlugin } from 'umi-types';
+import { IConfig, utils } from 'umi';
 import defaultSettings from './defaultSettings'; // https://umijs.org/config/
 
-import slash from 'slash2';
 import themePluginConfig from './themePluginConfig';
 import proxy from './proxy';
-
-const { pwa } = defaultSettings;
 
 // preview.pro.ant.design only do not use in your production ;
 // preview.pro.ant.design 专用环境变量，请不要在你的项目中使用它。
 const { ANT_DESIGN_PRO_ONLY_DO_NOT_USE_IN_YOUR_PRODUCTION, REACT_APP_ENV } = process.env;
 const isAntDesignProPreview = ANT_DESIGN_PRO_ONLY_DO_NOT_USE_IN_YOUR_PRODUCTION === 'site';
-const plugins: IPlugin[] = [
-  ['umi-plugin-antd-icon-config', {}],
-  [
-    'umi-plugin-react',
-    {
-      antd: true,
-      dva: {
-        hmr: true,
-      },
-      locale: {
-        // default false
-        enable: true,
-        // default zh-CN
-        default: 'zh-CN',
-        // default true, when it is true, will use `navigator.language` overwrite default
-        baseNavigator: true,
-      },
-      dynamicImport: {
-        loadingComponent: './components/PageLoading/index',
-        webpackChunkName: true,
-        level: 3,
-      },
-      pwa: pwa
-        ? {
-            workboxPluginMode: 'InjectManifest',
-            workboxOptions: {
-              importWorkboxFrom: 'local',
-            },
-          }
-        : false,
-      // default close dll, because issue https://github.com/ant-design/ant-design-pro/issues/4665
-      // dll features https://webpack.js.org/plugins/dll-plugin/
-      // dll: {
-      //   include: ['dva', 'dva/router', 'dva/saga', 'dva/fetch'],
-      //   exclude: ['@babel/runtime', 'netlify-lambda'],
-      // },
-    },
-  ],
-  [
-    'umi-plugin-pro-block',
-    {
-      moveMock: false,
-      moveService: false,
-      modifyRequest: true,
-      autoAddMenu: true,
-    },
-  ],
-];
+const plugins = [];
 
 if (isAntDesignProPreview) {
   // 针对 preview.pro.ant.design 的 GA 统计代码
@@ -72,7 +22,19 @@ if (isAntDesignProPreview) {
 }
 
 export default {
-  plugins,
+  // plugins,
+  antd: {},
+  dva: {
+    hmr: true,
+  },
+  locale: {
+    // default false
+    enable: true,
+    // default zh-CN
+    default: 'zh-CN',
+    // default true, when it is true, will use `navigator.language` overwrite default
+    baseNavigator: true,
+  },
   hash: true,
   targets: {
     ie: 11,
@@ -131,9 +93,10 @@ export default {
               path: '/list',
               component: './ListTableList',
             },
-            {
-              component: './404',
-            },
+            // not convert path
+            // {
+            //   component: './404',
+            // },
           ],
         },
         {
@@ -155,40 +118,41 @@ export default {
       ANT_DESIGN_PRO_ONLY_DO_NOT_USE_IN_YOUR_PRODUCTION || '', // preview.pro.ant.design only do not use in your production ; preview.pro.ant.design 专用环境变量，请不要在你的项目中使用它。
   },
   ignoreMomentLocale: true,
-  lessLoaderOptions: {
+  lessLoader: {
     javascriptEnabled: true,
   },
-  disableRedirectHoist: true,
-  cssLoaderOptions: {
-    modules: true,
-    getLocalIdent: (
-      context: {
-        resourcePath: string;
-      },
-      _: string,
-      localName: string,
-    ) => {
-      if (
-        context.resourcePath.includes('node_modules') ||
-        context.resourcePath.includes('ant.design.pro.less') ||
-        context.resourcePath.includes('global.less')
-      ) {
+  cssLoader: {
+    modules: {
+      getLocalIdent: (
+        context: {
+          resourcePath: string;
+        },
+        _: string,
+        localName: string,
+      ) => {
+        if (
+          context.resourcePath.includes('node_modules') ||
+          context.resourcePath.includes('ant.design.pro.less') ||
+          context.resourcePath.includes('global.less')
+        ) {
+          return localName;
+        }
+
+        const match = context.resourcePath.match(/src(.*)/);
+
+        if (match && match[1]) {
+          const antdProPath = match[1].replace('.less', '');
+          const arr = utils
+            .winPath(antdProPath)
+            .split('/')
+            .map((a: string) => a.replace(/([A-Z])/g, '-$1'))
+            .map((a: string) => a.toLowerCase());
+          return `antd-pro${arr.join('-')}-${localName}`.replace(/--/g, '-');
+        }
+
         return localName;
-      }
-      const match = context.resourcePath.match(/src(.*)/);
-      if (match && match[1]) {
-        const antdProPath = match[1].replace('.less', '');
-        const arr = slash(antdProPath)
-          .split('/')
-          .map((a: string) => a.replace(/([A-Z])/g, '-$1'))
-          .map((a: string) => a.toLowerCase());
-        return `antd-pro${arr.join('-')}-${localName}`.replace(/--/g, '-');
-      }
-      return localName;
+      },
     },
-  },
-  manifest: {
-    basePath: '/',
   },
   proxy: proxy[REACT_APP_ENV || 'dev'],
 } as IConfig;

--- a/config/config.ts
+++ b/config/config.ts
@@ -93,10 +93,9 @@ export default {
               path: '/list',
               component: './ListTableList',
             },
-            // not convert path
-            // {
-            //   component: './404',
-            // },
+            {
+              component: './404',
+            },
           ],
         },
         {

--- a/package.json
+++ b/package.json
@@ -77,11 +77,7 @@
     "react-dom": "^16.8.6",
     "react-helmet": "^5.2.1",
     "redux": "^4.0.1",
-    "umi": "^2.13.0",
-    "umi-plugin-antd-icon-config": "^1.0.2",
-    "umi-plugin-antd-theme": "^1.0.1",
-    "umi-plugin-pro-block": "^1.3.2",
-    "umi-plugin-react": "^1.14.10",
+    "umi": "^3.0.0-0",
     "umi-request": "^1.0.8",
     "use-merge-value": "^1.0.1"
   },
@@ -118,11 +114,10 @@
     "prettier": "^1.19.1",
     "pro-download": "1.0.1",
     "serverless-http": "^2.0.2",
-    "stylelint": "^13.0.0",
-    "umi-plugin-antd-icon-config": "^1.0.2",
-    "umi-plugin-ga": "^1.1.3",
-    "umi-plugin-pro": "^1.0.2",
-    "umi-types": "^0.5.9"
+    "@umijs/plugin-antd": "^0.2.0",
+    "@umijs/plugin-dva": "^0.1.2",
+    "@umijs/plugin-locale": "^0.1.2",
+    "stylelint": "^13.0.0"
   },
   "optionalDependencies": {
     "puppeteer": "^2.0.0"

--- a/src/components/SelectLang/index.tsx
+++ b/src/components/SelectLang/index.tsx
@@ -1,6 +1,6 @@
 import { GlobalOutlined } from '@ant-design/icons';
 import { Menu } from 'antd';
-import { getLocale, setLocale } from 'umi-plugin-react/locale';
+import { getLocale, setLocale } from 'umi';
 import { ClickParam } from 'antd/es/menu';
 import React from 'react';
 import classNames from 'classnames';

--- a/src/global.tsx
+++ b/src/global.tsx
@@ -1,7 +1,7 @@
 import { Button, message, notification } from 'antd';
 
 import React from 'react';
-import { formatMessage } from 'umi-plugin-react/locale';
+import { formatMessage } from 'umi';
 import defaultSettings from '../config/defaultSettings';
 
 const { pwa } = defaultSettings;

--- a/src/layouts/BasicLayout.tsx
+++ b/src/layouts/BasicLayout.tsx
@@ -9,9 +9,8 @@ import ProLayout, {
   Settings,
   DefaultFooter,
 } from '@ant-design/pro-layout';
-import { formatMessage } from 'umi-plugin-react/locale';
 import React, { useEffect } from 'react';
-import { Link } from 'umi';
+import { Link, useIntl } from 'umi';
 import { Dispatch } from 'redux';
 import { connect } from 'dva';
 import { GithubOutlined } from '@ant-design/icons';
@@ -147,10 +146,11 @@ const BasicLayout: React.FC<BasicLayoutProps> = props => {
   const authorized = getAuthorityFromRouter(props.route.routes, location.pathname || '/') || {
     authority: undefined,
   };
+  const intl = useIntl();
   return (
     <ProLayout
       logo={logo}
-      formatMessage={formatMessage}
+      formatMessage={intl.formatMessage}
       menuHeaderRender={(logoDom, titleDom) => (
         <Link to="/">
           {logoDom}

--- a/src/layouts/UserLayout.tsx
+++ b/src/layouts/UserLayout.tsx
@@ -1,8 +1,7 @@
 import { DefaultFooter, MenuDataItem, getMenuData, getPageTitle } from '@ant-design/pro-layout';
 import { Helmet } from 'react-helmet';
-import { Link } from 'umi';
+import { Link, useIntl } from 'umi';
 import React from 'react';
-import { formatMessage } from 'umi-plugin-react/locale';
 import { connect } from 'dva';
 import SelectLang from '@/components/SelectLang';
 import { ConnectProps, ConnectState } from '@/models/connect';
@@ -29,9 +28,10 @@ const UserLayout: React.FC<UserLayoutProps> = props => {
     },
   } = props;
   const { breadcrumb } = getMenuData(routes);
+  const intl = useIntl();
   const title = getPageTitle({
     pathname: location.pathname,
-    formatMessage,
+    formatMessage: intl.formatMessage,
     breadcrumb,
     ...props,
   });


### PR DESCRIPTION
## umi 层

内层 404 路由没转

![](https://raw.githubusercontent.com/ycjcl868/cdn/master/20200213114136.png?token=ADHXG5PQBFW5UWMQSE5BWC26JYB6K)


## 插件层

1. 国际化插件有点问题

![](https://raw.githubusercontent.com/ycjcl868/cdn/master/20200213115034.png?token=ADHXG5MBQFXPMVIP7PAOXHC6JYCAA)

2. pwa 插件没有

3. dynamicImport 变成自动开启，没有 loading 组件配置

4. manifest 插件没有

5. 以下插件要迁成 umi@3
- umi-plugin-antd-theme 
- umi-plugin-antd-icon-config
- umi-plugin-pro-block
- umi-plugin-pro
- umi-plugin-ga
