### PR TITLE
Resolve some 404 problem beyond causing by network issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@ant-design/icons": "^4.0.0-alpha.19",
     "@ant-design/pro-layout": "^5.0.0",
     "@ant-design/pro-table": "^2.0.0",
-    "@antv/data-set": "^0.10.2",
+    "@antv/data-set": "^0.11.1",
     "antd": "^4.0.0-rc.1",
     "classnames": "^2.2.6",
     "dva": "^2.6.0-beta.16",


### PR DESCRIPTION
Yesterday I started a new project using fetch block, and I got 404 problem.
I noticed the [Issue 4832](https://github.com/ant-design/ant-design-pro/issues/4823), so I debug from changing repositories to clearing the umi cache, and always got the same 404 error as below showed. 
![image](https://tva1.sinaimg.cn/large/00831rSTgy1gcd41trwrvj31n40u010p.jpg)

So I decided to add pages one by one, and I found that some components relying on antv/data-set have upgraded from 0.10.2 to 0.11.1, such as 【analysis】and most 【editor】 components， when I changed the version, the problem solved.

the error is :
Execute task error Error: find dependencies conflict between block and your project:* @antv/data-set: ^0.10.2(your project) not compatible with ^0.11.1(block)

PS: I wondered why there is no bug message when I ran fetch:blocks, and told me it's success.