### PR TITLE
禁用umi.js内置的 title 渲染机制

### DIFF
--- a/config/config.ts
+++ b/config/config.ts
@@ -97,6 +97,7 @@ export default defineConfig({
     // ...darkTheme,
     'primary-color': defaultSettings.primaryColor,
   },
+  title: false,
   ignoreMomentLocale: true,
   proxy: proxy[REACT_APP_ENV || 'dev'],
   manifest: {


### PR DESCRIPTION
close #6306 
umi内置了默认为 “” 的 title，
导致每次切换页面时，在pro-layout更改完title后，umi又改为“”，
根据[umi官方配置文档](https://umijs.org/config#title)关闭了内置的title更新