### PR TITLE
修改hash路由下search参数在hash之前，search最后一个参数错误bug

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -21,4 +21,18 @@ export const isAntDesignProOrDev = (): boolean => {
   return isAntDesignPro();
 };
 
-export const getPageQuery = () => parse(window.location.href.split('?')[1]);
+export const getPageQuery = () => {
+  const { href } = window.location;
+  const qsIndex = href.indexOf('?');
+  const sharpIndex = href.indexOf('#');
+
+  if (qsIndex !== -1) {
+    if (qsIndex > sharpIndex) {
+      return parse(href.split('?')[1]);
+    }
+
+    return parse(href.slice(qsIndex + 1, sharpIndex));
+  }
+
+  return {};
+};


### PR DESCRIPTION
例如  http://www.baidu.com?code=081kwzU70XCmVB1RkmW70vvYU70kwzU9&state=STATE#/wechat-auth  中state参数会被解析成STATE#/wechat-auth