### PR TITLE
:bug: 修复切换不同权限的账户登录后，access的鉴权不生效问题

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,5 +24,5 @@ jobs:
           ANT_DESIGN_PRO_ONLY_DO_NOT_USE_IN_YOUR_PRODUCTION: site
           GITHUB_TOKEN: ${{ secrets.ACTION_TOKEN }}
           BRANCH: gh-pages
-          FOLDER: "dist/"
+          FOLDER: 'dist/'
           BUILD_SCRIPT: yarn &&  npm uninstall husky && yarn add umi-plugin-setting-drawer umi-plugin-antd-theme umi-plugin-pro  && yarn run pro fetch-blocks && npm run site && git checkout . && git clean -df

--- a/src/pages/user/login/index.tsx
+++ b/src/pages/user/login/index.tsx
@@ -1,7 +1,7 @@
 import { AlipayCircleOutlined, TaobaoCircleOutlined, WeiboCircleOutlined } from '@ant-design/icons';
 import { Alert, Checkbox, message } from 'antd';
 import React, { useState } from 'react';
-import { Link, SelectLang, history, useModel } from 'umi';
+import { Link, SelectLang, useModel } from 'umi';
 import { getPageQuery } from '@/utils/utils';
 import logo from '@/assets/logo.svg';
 import { LoginParamsType, fakeAccountLogin } from '@/services/login';
@@ -43,7 +43,7 @@ const replaceGoto = () => {
       return;
     }
   }
-  history.replace(redirect || '/');
+  window.location.href = urlParams.href.split(urlParams.pathname)[0] + (redirect || '/');
 };
 
 const Login: React.FC<{}> = () => {


### PR DESCRIPTION
**期望**：切换不同权限的账户登录后，路由鉴权重新加载

**实际**：使用history跳转页面，refresh()后，路由鉴权并没有正常加载，仍然是读的缓存数据。

**解决方案**：
修改登录成功后跳转的方式，使用浏览器自带的window.location.href跳转。
同时兼容非根目录部署的情况。
页面重新加载后，鉴权正常。