### PR TITLE
fix: 修复高级表单未保存但可以提交的bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,10 +59,10 @@
   ],
   "dependencies": {
     "@ant-design/icons": "^4.0.0",
-    "@ant-design/pro-layout": "^6.0.0",
-    "@ant-design/pro-table": "^2.4.0",
+    "@ant-design/pro-layout": "^6.2.4",
+    "@ant-design/pro-table": "^2.4.2",
     "@antv/data-set": "^0.11.0",
-    "@antv/l7-react": "^2.1.9",
+    "@antv/l7-react": "^2.2.22",
     "@types/lodash.debounce": "^4.0.6",
     "@types/lodash.isequal": "^4.5.5",
     "antd": "^4.4.0",

--- a/src/pages/ListTableList/index.tsx
+++ b/src/pages/ListTableList/index.tsx
@@ -181,7 +181,10 @@ const TableList: React.FC<{}> = () => {
             onClick={async () => {
               await handleRemove(selectedRowsState);
               setSelectedRows([]);
-              actionRef.current?.reloadAndRest();
+              const reloadAndRest = actionRef.current?.reloadAndRest;
+              if (reloadAndRest) {
+                reloadAndRest();
+              }
             }}
           >
             批量删除

--- a/src/pages/dashboard/analysis/components/Charts/ChartCard/index.tsx
+++ b/src/pages/dashboard/analysis/components/Charts/ChartCard/index.tsx
@@ -4,9 +4,9 @@ import React from 'react';
 import classNames from 'classnames';
 import styles from './index.less';
 
-type totalType = () => React.ReactNode;
+type TotalType = () => React.ReactNode;
 
-const renderTotal = (total?: number | totalType | React.ReactNode) => {
+const renderTotal = (total?: number | TotalType | React.ReactNode) => {
   if (!total && total !== 0) {
     return null;
   }

--- a/src/pages/form/advanced-form/components/TableForm.tsx
+++ b/src/pages/form/advanced-form/components/TableForm.tsx
@@ -6,13 +6,12 @@ import { TableFormDateType } from '../../data';
 import styles from '../style.less';
 
 interface TableFormProps {
-  value?: TableFormDateType[];
   onChange?: (value: TableFormDateType[]) => void;
   data?: TableFormDateType[];
   setData?: (value: TableFormDateType[]) => void;
 }
 
-const TableForm: FC<TableFormProps> = ({ value, onChange, data, setData }) => {
+const TableForm: FC<TableFormProps> = ({ onChange, data, setData }) => {
   const [clickedCancel, setClickedCancel] = useState(false);
   const [loading, setLoading] = useState(false);
   const [index, setIndex] = useState(0);
@@ -32,7 +31,9 @@ const TableForm: FC<TableFormProps> = ({ value, onChange, data, setData }) => {
         setCacheOriginData(cacheOriginData);
       }
       target.editable = !target.editable;
-      setData?.(newData);
+      if (setData) {
+        setData(newData);
+      }
     }
   };
   const newMember = () => {
@@ -48,12 +49,16 @@ const TableForm: FC<TableFormProps> = ({ value, onChange, data, setData }) => {
     });
 
     setIndex(index + 1);
-    setData?.(newData);
+    if (setData) {
+      setData(newData);
+    }
   };
 
   const remove = (key: string) => {
     const newData = data?.filter((item) => item.key !== key) as TableFormDateType[];
-    setData?.(newData);
+    if (setData) {
+      setData(newData);
+    }
     if (onChange) {
       onChange(newData);
     }
@@ -68,7 +73,9 @@ const TableForm: FC<TableFormProps> = ({ value, onChange, data, setData }) => {
     const target = getRowByKey(key, newData);
     if (target) {
       target[fieldName] = e.target.value;
-      setData?.(newData);
+      if (setData) {
+        setData(newData);
+      }
     }
   };
 
@@ -123,7 +130,9 @@ const TableForm: FC<TableFormProps> = ({ value, onChange, data, setData }) => {
       }
       return item;
     });
-    setData?.(cacheData);
+    if (setData) {
+      setData(cacheData);
+    }
     setClickedCancel(false);
   };
 

--- a/src/pages/form/advanced-form/components/TableForm.tsx
+++ b/src/pages/form/advanced-form/components/TableForm.tsx
@@ -1,35 +1,29 @@
 import { PlusOutlined } from '@ant-design/icons';
 import { Button, Divider, Input, Popconfirm, Table, message } from 'antd';
 import React, { FC, useState } from 'react';
+import { TableFormDateType } from '../../data';
 
 import styles from '../style.less';
 
-interface TableFormDateType {
-  key: string;
-  workId?: string;
-  name?: string;
-  department?: string;
-  isNew?: boolean;
-  editable?: boolean;
-}
 interface TableFormProps {
   value?: TableFormDateType[];
   onChange?: (value: TableFormDateType[]) => void;
+  data?: TableFormDateType[];
+  setData?: (value: TableFormDateType[]) => void;
 }
 
-const TableForm: FC<TableFormProps> = ({ value, onChange }) => {
+const TableForm: FC<TableFormProps> = ({ value, onChange, data, setData }) => {
   const [clickedCancel, setClickedCancel] = useState(false);
   const [loading, setLoading] = useState(false);
   const [index, setIndex] = useState(0);
   const [cacheOriginData, setCacheOriginData] = useState({});
-  const [data, setData] = useState(value);
 
   const getRowByKey = (key: string, newData?: TableFormDateType[]) =>
     (newData || data)?.filter((item) => item.key === key)[0];
 
   const toggleEditable = (e: React.MouseEvent | React.KeyboardEvent, key: string) => {
     e.preventDefault();
-    const newData = data?.map((item) => ({ ...item }));
+    const newData = data?.map((item) => ({ ...item })) || [];
     const target = getRowByKey(key, newData);
     if (target) {
       // 进入编辑状态时保存原始数据
@@ -38,7 +32,7 @@ const TableForm: FC<TableFormProps> = ({ value, onChange }) => {
         setCacheOriginData(cacheOriginData);
       }
       target.editable = !target.editable;
-      setData(newData);
+      setData?.(newData);
     }
   };
   const newMember = () => {
@@ -54,12 +48,12 @@ const TableForm: FC<TableFormProps> = ({ value, onChange }) => {
     });
 
     setIndex(index + 1);
-    setData(newData);
+    setData?.(newData);
   };
 
   const remove = (key: string) => {
     const newData = data?.filter((item) => item.key !== key) as TableFormDateType[];
-    setData(newData);
+    setData?.(newData);
     if (onChange) {
       onChange(newData);
     }
@@ -74,7 +68,7 @@ const TableForm: FC<TableFormProps> = ({ value, onChange }) => {
     const target = getRowByKey(key, newData);
     if (target) {
       target[fieldName] = e.target.value;
-      setData(newData);
+      setData?.(newData);
     }
   };
 
@@ -129,7 +123,7 @@ const TableForm: FC<TableFormProps> = ({ value, onChange }) => {
       }
       return item;
     });
-    setData(cacheData);
+    setData?.(cacheData);
     setClickedCancel(false);
   };
 

--- a/src/pages/form/advanced-form/index.tsx
+++ b/src/pages/form/advanced-form/index.tsx
@@ -1,5 +1,17 @@
 import { CloseCircleOutlined } from '@ant-design/icons';
-import { Button, Card, Col, DatePicker, Form, Input, Popover, Row, Select, TimePicker } from 'antd';
+import {
+  Button,
+  Card,
+  Col,
+  DatePicker,
+  Form,
+  Input,
+  Popover,
+  Row,
+  Select,
+  TimePicker,
+  message,
+} from 'antd';
 
 import React, { FC, useState } from 'react';
 import { PageHeaderWrapper } from '@ant-design/pro-layout';
@@ -7,6 +19,7 @@ import { connect, Dispatch } from 'umi';
 import TableForm from './components/TableForm';
 import FooterToolbar from './components/FooterToolbar';
 import styles from './style.less';
+import { TableFormDateType } from '../data';
 
 type InternalNamePath = (string | number)[];
 
@@ -62,6 +75,8 @@ interface ErrorField {
 const AdvancedForm: FC<AdvancedFormProps> = ({ submitting, dispatch }) => {
   const [form] = Form.useForm();
   const [error, setError] = useState<ErrorField[]>([]);
+  const [data, setData] = useState<TableFormDateType[]>(tableData);
+
   const getErrorInfo = (errors: ErrorField[]) => {
     const errorCount = errors.filter((item) => item.errors.length > 0).length;
     if (!errors || errorCount === 0) {
@@ -109,6 +124,12 @@ const AdvancedForm: FC<AdvancedFormProps> = ({ submitting, dispatch }) => {
 
   const onFinish = (values: { [key: string]: any }) => {
     setError([]);
+    for (const item of data ?? []) {
+      if (item.editable) {
+        message.error('请在提交前保存数据。');
+        return;
+      }
+    }
     dispatch({
       type: 'formAndadvancedForm/submitAdvancedForm',
       payload: values,
@@ -283,7 +304,7 @@ const AdvancedForm: FC<AdvancedFormProps> = ({ submitting, dispatch }) => {
         </Card>
         <Card title="成员管理" bordered={false}>
           <Form.Item name="members">
-            <TableForm />
+            <TableForm data={data} setData={setData} />
           </Form.Item>
         </Card>
       </PageHeaderWrapper>

--- a/src/pages/form/advanced-form/index.tsx
+++ b/src/pages/form/advanced-form/index.tsx
@@ -124,12 +124,14 @@ const AdvancedForm: FC<AdvancedFormProps> = ({ submitting, dispatch }) => {
 
   const onFinish = (values: { [key: string]: any }) => {
     setError([]);
-    for (const item of data ?? []) {
-      if (item.editable) {
+
+    for (let i = 0; i < data.length; i += 1) {
+      if (data[i].editable) {
         message.error('请在提交前保存数据。');
         return;
       }
     }
+
     dispatch({
       type: 'formAndadvancedForm/submitAdvancedForm',
       payload: values,

--- a/src/pages/form/data.d.ts
+++ b/src/pages/form/data.d.ts
@@ -1,0 +1,8 @@
+export interface TableFormDateType {
+  key: string;
+  workId?: string;
+  name?: string;
+  department?: string;
+  isNew?: boolean;
+  editable?: boolean;
+}

--- a/src/pages/list/search/applications/components/TagSelect/index.tsx
+++ b/src/pages/list/search/applications/components/TagSelect/index.tsx
@@ -60,14 +60,14 @@ class TagSelect extends Component<TagSelectProps, TagSelectState> {
     },
   };
 
+  static Option: TagSelectOption = TagSelectOption;
+
   static getDerivedStateFromProps(nextProps: TagSelectProps) {
     if ('value' in nextProps) {
       return { value: nextProps.value || [] };
     }
     return null;
   }
-
-  static Option: TagSelectOption = TagSelectOption;
 
   constructor(props: TagSelectProps) {
     super(props);

--- a/src/pages/list/search/applications/components/TagSelect/index.tsx
+++ b/src/pages/list/search/applications/components/TagSelect/index.tsx
@@ -67,6 +67,8 @@ class TagSelect extends Component<TagSelectProps, TagSelectState> {
     return null;
   }
 
+  static Option: TagSelectOption = TagSelectOption;
+
   constructor(props: TagSelectProps) {
     super(props);
     this.state = {
@@ -126,8 +128,6 @@ class TagSelect extends Component<TagSelectProps, TagSelectState> {
     node &&
     node.type &&
     (node.type.isTagSelectOption || node.type.displayName === 'TagSelectOption');
-
-  static Option: TagSelectOption = TagSelectOption;
 
   render() {
     const { value, expand } = this.state;

--- a/src/pages/list/search/articles/components/TagSelect/index.tsx
+++ b/src/pages/list/search/articles/components/TagSelect/index.tsx
@@ -60,14 +60,14 @@ class TagSelect extends Component<TagSelectProps, TagSelectState> {
     },
   };
 
+  static Option: TagSelectOption = TagSelectOption;
+
   static getDerivedStateFromProps(nextProps: TagSelectProps) {
     if ('value' in nextProps) {
       return { value: nextProps.value || [] };
     }
     return null;
   }
-
-  static Option: TagSelectOption = TagSelectOption;
 
   constructor(props: TagSelectProps) {
     super(props);

--- a/src/pages/list/search/articles/components/TagSelect/index.tsx
+++ b/src/pages/list/search/articles/components/TagSelect/index.tsx
@@ -67,6 +67,8 @@ class TagSelect extends Component<TagSelectProps, TagSelectState> {
     return null;
   }
 
+  static Option: TagSelectOption = TagSelectOption;
+
   constructor(props: TagSelectProps) {
     super(props);
     this.state = {
@@ -126,8 +128,6 @@ class TagSelect extends Component<TagSelectProps, TagSelectState> {
     node &&
     node.type &&
     (node.type.isTagSelectOption || node.type.displayName === 'TagSelectOption');
-
-  static Option: TagSelectOption = TagSelectOption;
 
   render() {
     const { value, expand } = this.state;

--- a/src/pages/list/search/projects/components/TagSelect/index.tsx
+++ b/src/pages/list/search/projects/components/TagSelect/index.tsx
@@ -62,14 +62,14 @@ class TagSelect extends Component<TagSelectProps, TagSelectState> {
     },
   };
 
+  static Option: TagSelectOptionType = TagSelectOption;
+
   static getDerivedStateFromProps(nextProps: TagSelectProps) {
     if ('value' in nextProps) {
       return { value: nextProps.value || [] };
     }
     return null;
   }
-
-  static Option: TagSelectOptionType = TagSelectOption;
 
   constructor(props: TagSelectProps) {
     super(props);

--- a/src/pages/list/search/projects/components/TagSelect/index.tsx
+++ b/src/pages/list/search/projects/components/TagSelect/index.tsx
@@ -69,6 +69,8 @@ class TagSelect extends Component<TagSelectProps, TagSelectState> {
     return null;
   }
 
+  static Option: TagSelectOptionType = TagSelectOption;
+
   constructor(props: TagSelectProps) {
     super(props);
     this.state = {
@@ -128,8 +130,6 @@ class TagSelect extends Component<TagSelectProps, TagSelectState> {
     node &&
     node.type &&
     (node.type.isTagSelectOption || node.type.displayName === 'TagSelectOption');
-
-  static Option: TagSelectOptionType = TagSelectOption;
 
   render() {
     const { value, expand } = this.state;


### PR DESCRIPTION
当前高级表单的table未保存但可以提交，存在以下bug

- bug描述
编辑两条数据，但只保存一条，点提交时，未保存的数据也被提交了。

- 复现步骤
1. 进入高级表单页面填写完表单数据；
2. 同时编辑第2条和第3条table数据；
3. 保存第3条数据并提交；
4. 现状：第2条未保存的数据也被提交了。
![image](https://user-images.githubusercontent.com/57212574/87846161-48654200-c900-11ea-8833-d9c8c0ccf511.png)

- 期望结果
第2条未保存的数据不被提交，并提示“请在提交前保存数据。”

- 补充
同理，编辑不保存，然后新增保存再提交，未保存的数据也被提交了。或者编辑不保存，然后删除另外一条数据再提交，未保存的数据也被提交了。

- 解决方案
在提交前校验是否有未保存的数据，如果有则提示“请在提交前保存数据。”