### PR TITLE
config.js里面 history.type 为 hash时，退出重登录后，拼接返回路径时，#号前路径会重复

### DIFF
--- a/src/pages/user/login/index.tsx
+++ b/src/pages/user/login/index.tsx
@@ -36,7 +36,7 @@ const replaceGoto = () => {
     if (redirectUrlParams.origin === urlParams.origin) {
       redirect = redirect.substr(urlParams.origin.length);
       if (redirect.match(/^\/.*#/)) {
-        redirect = redirect.substr(redirect.indexOf('#') + 1);
+        redirect = redirect.substr(redirect.indexOf('#'));
       }
     } else {
       window.location.href = '/';


### PR DESCRIPTION
例如 在 http://localhost:8000/#/account/settings 退出，再登录
会跳转到 http://localhost:8000/account/settings#/welcome

正确的情况下应该跳回 http://localhost:8000/#/account/settings 