### PR TITLE
feat: 修复eslint中mock文件未被引用的报错

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,7 +32,8 @@
     ".eslintrc.js",
     ".stylelintrc.js",
     ".prettierrc.js",
-    "jest.config.js"
+    "jest.config.js",
+    "mock/*"
   ],
   "exclude": ["node_modules", "build", "dist", "scripts", "src/.umi/*", "webpack", "jest"]
 }


### PR DESCRIPTION
我在使用的时候，遇到了这个eslint问题

https://github.com/ant-design/ant-design-pro/issues/7540

根据作者提升修复了这个问题，提个MR，解决一下这个问题
