### PR TITLE
bufix: 修改config/proxy.js中api地址

### DIFF
--- a/config/proxy.ts
+++ b/config/proxy.ts
@@ -1,3 +1,10 @@
+/*
+ * @Author       : 李才人
+ * @Date         : 2021-03-15 16:04:11
+ * @LastEditors  : 李才人(7737841@qq.com)
+ * @LastEditTime : 2021-03-15 16:06:07
+ * @FilePath     : /ant-design-pro/config/proxy.ts
+ */
 /**
  * 在生产环境 代理是无法生效的，所以这里没有生产环境的配置
  * The agent cannot take effect in the production environment
@@ -8,14 +15,14 @@
 export default {
   dev: {
     '/api/': {
-      target: 'https://preview.pro.ant.design',
+      target: 'https://proapi.azurewebsites.net',
       changeOrigin: true,
       pathRewrite: { '^': '' },
     },
   },
   test: {
     '/api/': {
-      target: 'https://preview.pro.ant.design',
+      target: 'https://proapi.azurewebsites.net',
       changeOrigin: true,
       pathRewrite: { '^': '' },
     },

--- a/config/proxy.ts
+++ b/config/proxy.ts
@@ -1,10 +1,3 @@
-/*
- * @Author       : 李才人
- * @Date         : 2021-03-15 16:04:11
- * @LastEditors  : 李才人(7737841@qq.com)
- * @LastEditTime : 2021-03-15 16:06:07
- * @FilePath     : /ant-design-pro/config/proxy.ts
- */
 /**
  * 在生产环境 代理是无法生效的，所以这里没有生产环境的配置
  * The agent cannot take effect in the production environment


### PR DESCRIPTION
使用config/proxy.ts中的代理地址登录报错如下：
修改api地址 https://preview.pro.ant.design => https://proapi.azurewebsites.net