### PR TITLE
fix English README link

### DIFF
--- a/README.ar-DZ.md
+++ b/README.ar-DZ.md
@@ -1,4 +1,4 @@
-[English](./README.zh-CN.md) | [简体中文](./README.zh-CN.md) | [Русский](./README.ru-RU.md) | [Türkçe](./README.tr-TR.md) | [日本語](./README.ja-JP.md) | [Français](./README.fr-FR.md) | [Português](./README.pt-BR.md) | العربية
+[English](./README.md) | [简体中文](./README.zh-CN.md) | [Русский](./README.ru-RU.md) | [Türkçe](./README.tr-TR.md) | [日本語](./README.ja-JP.md) | [Français](./README.fr-FR.md) | [Português](./README.pt-BR.md) | العربية
 
 <h1 align="center">Ant Design Pro</h1>
 <div dir="rtl">


### PR DESCRIPTION
English docs in README.ar-DZ.md was `[English](./README.zh-CN.md)`. So, I replaced it with `[English](./README.md)`.

-----
[View rendered README.ar-DZ.md](https://github.com/kevinadhiguna/ant-design-pro/blob/master/README.ar-DZ.md)