### PR TITLE
ci: update issue-open-check.yml

### DIFF
--- a/.github/workflows/issue-open-check.yml
+++ b/.github/workflows/issue-open-check.yml
@@ -15,7 +15,7 @@ jobs:
           issue-number: ${{ github.event.issue.number }}
           title-excludes: '🐛[BUG], 👑 [需求], 🧐[问题]'
 
-      - if: steps.check.outputs.check-result == 'false' && github.event.action == 'opened'
+      - if: steps.check.outputs.check-result == 'false' && github.event.issue.state == 'open'
         uses: actions-cool/issues-helper@v2.2.0
         with:
           actions: 'create-comment, close-issue'

--- a/.github/workflows/issue-open-check.yml
+++ b/.github/workflows/issue-open-check.yml
@@ -15,7 +15,7 @@ jobs:
           issue-number: ${{ github.event.issue.number }}
           title-excludes: '🐛[BUG], 👑 [需求], 🧐[问题]'
 
-      - if: steps.check.outputs.check-result == 'false'
+      - if: steps.check.outputs.check-result == 'false' && github.event.action == 'opened'
         uses: actions-cool/issues-helper@v2.2.0
         with:
           actions: 'create-comment, close-issue'


### PR DESCRIPTION
只对新开的 issue 进行校验，当用户修改 issue 后，若标题仍校验为空，则不再触发二次评论

还有一种方案是 校验 issue 的状态为 open 的时候，就怕遇到，新开 issue 标题有，然后 用户又把标题删了的。。。不过很少有这种吧