### PR TITLE
fix jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   testURL: 'http://localhost:8000',
   testEnvironment: './tests/PuppeteerEnvironment',
   verbose: false,
-  extraSetupFiles: ['./tests/setupTests.js'],
+  setupFilesAfterEnv: ['./tests/setupTests.js'],
   globals: {
     ANT_DESIGN_PRO_ONLY_DO_NOT_USE_IN_YOUR_PRODUCTION: false,
     localStorage: null,


### PR DESCRIPTION
Correct the option name of setup files in jest configuration, or else the Unknown option warning will be shown with test, and the setup code would not actually run with the previous option.