### PR TITLE
Remove deprecated `url.parse`

### DIFF
--- a/mock/listTableList.ts
+++ b/mock/listTableList.ts
@@ -1,6 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { Request, Response } from 'express';
-import { parse } from 'url';
 import { TableListItem, TableListParams } from '@/pages/TableList/data';
 
 // mock tableListDataSource
@@ -39,7 +38,7 @@ function getRule(req: Request, res: Response, u: string) {
     realUrl = req.url;
   }
   const { current = 1, pageSize = 10 } = req.query;
-  const params = (parse(realUrl, true).query as unknown) as TableListParams;
+  const params = (new URLSearchParams(realUrl.split('?')[1]) as unknown) as TableListParams;
 
   let dataSource = [...tableListDataSource].slice(
     ((current as number) - 1) * (pageSize as number),


### PR DESCRIPTION
This API is deprecated. Changed to WHATWG URL API using `new URLSearchParams`

Currently PR to master branch, let me know if you hope to merge this into v5 branch instead.

Let me know if there are potential problems with my approach to remove this deprecated method call.
