### PR TITLE
fix: detect sorter's value first(#8979)

### DIFF
--- a/src/pages/list/table-list/_mock.ts
+++ b/src/pages/list/table-list/_mock.ts
@@ -45,8 +45,9 @@ function getRule(req: Request, res: Response, u: string) {
     ((current as number) - 1) * (pageSize as number),
     (current as number) * (pageSize as number),
   );
-  const sorter = JSON.parse(params.sorter as any);
-  if (sorter) {
+  
+  if (params.sorter) {
+    const sorter = JSON.parse(params.sorter as any);
     dataSource = dataSource.sort((prev, next) => {
       let sortNumber = 0;
       Object.keys(sorter).forEach((key) => {


### PR DESCRIPTION
detect params.sorter's value before parsing it