### PR TITLE
修复vscode点击代码引用不会跳转到组件

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "jsx": "react-jsx",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "baseUrl": ".",


### PR DESCRIPTION
js项目如果react组件引用缺少/index  vscode无法导航到定义