### PR TITLE
fix: dependencies were not found using pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "lodash": "^4.17.11",
     "moment": "^2.25.3",
     "omit.js": "^2.0.2",
+    "rc-util": "^5.14.0",
     "react": "^17.0.0",
     "react-dev-inspector": "^1.1.1",
     "react-dom": "^17.0.0",
@@ -104,6 +105,7 @@
     "prettier": "^2.3.2",
     "puppeteer-core": "^8.0.0",
     "stylelint": "^13.0.0",
+    "swagger-ui-react": "^3.52.3",
     "typescript": "^4.2.2"
   },
   "engines": {


### PR DESCRIPTION
Install the dependencies with pnpm, and compile. The compilation fails with error info:

```
These dependencies were not found:

* rc-util/es/hooks/useMergedState in ./src/components/HeaderSearch/index.tsx, ./src/components/NoticeIcon/NoticeIcon.tsx
* swagger-ui-react in ./src/.umi/plugin-openapi/openapi.tsx
* swagger-ui-react/swagger-ui.css in ./src/.umi/plugin-openapi/openapi.tsx

To install them, you can run: npm install --save rc-util/es/hooks/useMergedState swagger-ui-react swagger-ui-react/swagger-ui.css
```

Pnpm used a new non-flat structure to organize the dependencies, thus the dependencies need to be explicitly specified in package.json.
