### PR TITLE
replace proxy with proapi.azurewebsites.net/

### DIFF
--- a/config/proxy.ts
+++ b/config/proxy.ts
@@ -16,7 +16,7 @@ export default {
   },
   test: {
     '/api/': {
-      target: 'https://preview.pro.ant.design',
+      target: 'https://proapi.azurewebsites.net',
       changeOrigin: true,
       pathRewrite: { '^': '' },
     },


### PR DESCRIPTION
https://proapi.azurewebsites.net/api/currentuser return the json data
https://preview.pro.ant.design/api/currentuser return 404 page
without this commit, logoin would fail if start the app by "npm run dev"