### PR TITLE
fix: 修复 fabric.stylelint 与 IDE 的兼容问题

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,5 +1,5 @@
 const fabric = require('@umijs/fabric');
 
 module.exports = {
-  ...fabric.stylelint,
+  extends: [require.resolve('@umijs/fabric/dist/stylelint')],
 };

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,5 +1,3 @@
-const fabric = require('@umijs/fabric');
-
 module.exports = {
   extends: [require.resolve('@umijs/fabric/dist/stylelint')],
 };


### PR DESCRIPTION
使用原来的写法 Webstorm 的 stylelint 插件会找不到配置文件。

应该是 pnpm 没有扁平化安装依赖导致的，用 extends 语法就能解决

![image](https://user-images.githubusercontent.com/28819315/163357170-6f3c5539-0708-4c0f-9ea8-be09888a3af1.png)
