### PR TITLE
fix: route匹配404页面

### DIFF
--- a/config/routes.ts
+++ b/config/routes.ts
@@ -18,9 +18,6 @@ export default [
         path: '/user/login',
         component: './User/Login',
       },
-      {
-        component: './404',
-      },
     ],
   },
   {
@@ -41,9 +38,6 @@ export default [
         icon: 'smile',
         component: './Welcome',
       },
-      {
-        component: './404',
-      },
     ],
   },
   {
@@ -57,6 +51,7 @@ export default [
     redirect: '/welcome',
   },
   {
+    path: '*',
     component: './404',
   },
 ];


### PR DESCRIPTION
使用了umi4，旧的404页面的route配置方法无法生效，需要加个path为'*'