### PR TITLE
fix: 多余的文件

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ yarn.lock
 package-lock.json
 pnpm-lock.yaml
 *bak
+.vscode
 
 
 # visual studio code

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,0 @@
-{
-  "recommendations": ["esbenp.prettier-vscode", "dbaeumer.vscode-eslint", "wangzy.sneak-mark"]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-  "editor.formatOnSave": true,
-  "prettier.requireConfig": true,
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
-}


### PR DESCRIPTION
脚手架不应该上传编辑器的配置，不是vscode编辑器这个文件就是多余的。
之前5.0也没有这个