### PR TITLE
fix: RightContent 中的 navTheme 条件值

### DIFF
--- a/src/components/RightContent/index.tsx
+++ b/src/components/RightContent/index.tsx
@@ -18,7 +18,7 @@ const GlobalHeaderRight: React.FC = () => {
   const { navTheme, layout } = initialState.settings;
   let className = styles.right;
 
-  if ((navTheme === 'dark' && layout === 'top') || layout === 'mix') {
+  if ((navTheme === 'realDark' && layout === 'top') || layout === 'mix') {
     className = `${styles.right}  ${styles.dark}`;
   }
   return (


### PR DESCRIPTION
build (16.x, ubuntu-latest): src/components/RightContent/index.tsx#L1 This condition will always return 'false' since the types '"light" | "realDark" | undefined' and '"dark"' have no overlap.

https://github.com/ant-design/ant-design-pro/pull/10209/files#annotation_4543727834