### PR TITLE
Correct spelling

### DIFF
--- a/src/locales/en-US/pages.ts
+++ b/src/locales/en-US/pages.ts
@@ -63,6 +63,6 @@ export default {
   'pages.searchTable.item': 'item',
   'pages.searchTable.totalServiceCalls': 'Total Number of Service Calls',
   'pages.searchTable.tenThousand': '0000',
-  'pages.searchTable.batchDeletion': 'bacth deletion',
+  'pages.searchTable.batchDeletion': 'batch deletion',
   'pages.searchTable.batchApproval': 'batch approval',
 };


### PR DESCRIPTION
`bacth` -> `batch`