### PR TITLE
fix: Hash router is ignored in getInitialState()

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -33,7 +33,8 @@ export async function getInitialState(): Promise<{
     return undefined;
   };
   // 如果不是登录页面，执行
-  if (window.location.pathname !== loginPath) {
+  const { location } = history;
+  if (location.pathname !== loginPath) {
     const currentUser = await fetchUserInfo();
     return {
       fetchUserInfo,


### PR DESCRIPTION
Use `history.location.pathname` instead of `window.location.pathname` to support hash router.