### PR TITLE
fix: 修复antd5时间选择器语言包中文缺失问题

### DIFF
--- a/config/config.ts
+++ b/config/config.ts
@@ -81,6 +81,15 @@ export default defineConfig({
     ...defaultSettings,
   },
   /**
+   * @name moment2dayjs 插件
+   * @description 将项目中的 moment 替换为 dayjs
+   * @doc https://umijs.org/docs/max/moment2dayjs
+   */
+  moment2dayjs: {
+    preset: 'antd',
+    plugins: ['duration'],
+  },
+  /**
    * @name 国际化插件
    * @doc https://umijs.org/docs/max/i18n
    */


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/99160430/207495119-2c7b924f-6a56-4a20-a844-438763666145.png)
