### PR TITLE
fix(husky): Prevent the verify error on commit.

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "@types/react-helmet": "^6.1.5",
+    "@umijs/facrib": "^2.14.1",
     "@umijs/lint": "^4.0.34",
     "@umijs/max": "^4.0.33",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
If I initial my project by execute: pnpm install (not the npm install), Then use git commit, it'll always result an error:

✔ Preparing...
✔ Running tasks...
✔ Applying modifications...
✔ Cleaning up...
npm ERR! could not determine executable to run

npm ERR! A complete log of this run can be found in: husky - commit-msg hook exited with code 1 (error)

so I add a missed dev-depency: @umijs/facrib, It's solved.