### PR TITLE
fix: 修改默认设置，防止打包上线后未设置hash路由导致页面白屏。

### DIFF
--- a/config/config.ts
+++ b/config/config.ts
@@ -9,12 +9,20 @@ const { REACT_APP_ENV = 'dev' } = process.env;
 
 export default defineConfig({
   /**
+   * @name 设置路由history类型
+   * @description 用于在路由上加上#，因为hash默认值为true，避免打包上线后页面加载白屏，访问不到路由
+   * @doc https://umijs.org/docs/api/config#history
+   */
+  history: {
+    type: 'hash',
+  },
+
+  /**
    * @name 开启 hash 模式
    * @description 让 build 之后的产物包含 hash 后缀。通常用于增量发布和避免浏览器加载缓存。
    * @doc https://umijs.org/docs/api/config#hash
    */
   hash: true,
-
   /**
    * @name 兼容性设置
    * @description 设置 ie11 不一定完美兼容，需要检查自己使用的所有依赖


### PR DESCRIPTION
给默认设置添加了history相关设置，因为之前的默认设置设置了hash为true，但是又没有设置相对应的history相关设置，对于很多人来讲容易弄不清楚。