### PR TITLE
fix(TableList): Pass the fields as the request body to the request

### DIFF
--- a/src/pages/TableList/index.tsx
+++ b/src/pages/TableList/index.tsx
@@ -24,7 +24,7 @@ import UpdateForm from './components/UpdateForm';
 const handleAdd = async (fields: API.RuleListItem) => {
   const hide = message.loading('正在添加');
   try {
-    await addRule({ ...fields });
+    await addRule({data:{ ...fields }});
     hide();
     message.success('Added successfully');
     return true;


### PR DESCRIPTION
The current code passes `fields` as an argument object to both `request` and `axios`, which means it's not actually sending `fields` as the request body to the server.
It seems that `fields` should be passed as the `data` option to `request`.