### PR TITLE
fix: Modified the method of calculating total

### DIFF
--- a/mock/listTableList.ts
+++ b/mock/listTableList.ts
@@ -44,10 +44,7 @@ function getRule(req: Request, res: Response, u: string) {
       filter: any;
     };
 
-  let dataSource = [...tableListDataSource].slice(
-    ((current as number) - 1) * (pageSize as number),
-    (current as number) * (pageSize as number),
-  );
+  let dataSource = [...tableListDataSource];
   if (params.sorter) {
     const sorter = JSON.parse(params.sorter);
     dataSource = dataSource.sort((prev, next) => {
@@ -94,9 +91,14 @@ function getRule(req: Request, res: Response, u: string) {
   if (params.name) {
     dataSource = dataSource.filter((data) => data?.name?.includes(params.name || ''));
   }
+  const total = dataSource.length;
+  dataSource = dataSource.slice(
+    ((current as number) - 1) * (pageSize as number),
+    (current as number) * (pageSize as number),
+  );
   const result = {
     data: dataSource,
-    total: tableListDataSource.length,
+    total,
     success: true,
     pageSize,
     current: parseInt(`${params.current}`, 10) || 1,


### PR DESCRIPTION

In your `getRule` function, you are modifying `dataSource` several times based on different parameters (sorter, filter, name), and at the end of the function you return the total number of records as `tableListDataSource.length`. 

However, `tableListDataSource.length` is the total number of records before any filters or searches have been applied. If any filters or searches are applied, the `total` should reflect the number of records after these filters/searches have been applied, not the total number of records in `tableListDataSource`.

To fix this, you should update `total` to `dataSource.length` after all the filters and searches have been applied:

```
if (params.sorter) {dataSource=......}
if (params.filter) {dataSource=......}
if (params.name) {dataSource=......}
const total = dataSource.length;
```

Now, `total` will correctly reflect the number of records after all filters and searches have been applied.

![search](https://github.com/ant-design/ant-design-pro/assets/3096013/58b21af6-3406-404d-a988-5200dd4449ea)
