### PR TITLE
fix: fix a poor translation in settingDrawer.ts

### DIFF
--- a/src/locales/en-US/settingDrawer.ts
+++ b/src/locales/en-US/settingDrawer.ts
@@ -23,7 +23,7 @@ export default {
   'app.setting.hideheader': 'Hidden Header when scrolling',
   'app.setting.hideheader.hint': 'Works when Hidden Header is enabled',
   'app.setting.othersettings': 'Other Settings',
-  'app.setting.weakmode': 'Weak Mode',
+  'app.setting.weakmode': 'Color Blind Friendly Mode',
   'app.setting.copy': 'Copy Setting',
   'app.setting.copyinfo': 'copy success, please replace defaultSettings in src/models/setting.js',
   'app.setting.production.hint':


### PR DESCRIPTION
英文模式下对于“色弱模式”的翻译不准确。这个术语常用的英文翻译应为"color blind friendly mode"，可参考：
- https://venngage.com/blog/color-blind-friendly-palette/
- https://www.makeuseof.com/how-to-enable-color-blind-mode-asana/