### PR TITLE
fix: add umi-serve in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2",
     "umi-presets-pro": "^2.0.3"
+    "umi-serve": "^1.9.11"
   },
   "engines": {
     "node": ">=12.0.0"


### PR DESCRIPTION
在 `package.json` 中，提供了 `"serve": "umi-serve"` 命令，却没有添加 `umi-serve` 依赖，会导致运行该命令时出现 `umi-serve: not found` 错误。

根据 commit 历史，可以在此版本中该依赖还是在的： https://github.com/ant-design/ant-design-pro/blob/5963d69f904223ace1c2d579811b21e2daed5a7a/package.json#L85