### PR TITLE
chore: add path for 404 routes

### DIFF
--- a/config/routes.ts
+++ b/config/routes.ts
@@ -39,6 +39,7 @@ export default [
       },
       {
         component: '404',
+        path: '/*',
       },
     ],
   },
@@ -262,5 +263,6 @@ export default [
   },
   {
     component: '404',
+    path: '/*',
   },
 ];


### PR DESCRIPTION
为 404 路由添加通配 `path`，避免在启用 `exportStatic` 时报错