### PR TITLE
Fix blank page error after `npm start`

### DIFF
--- a/config/routes.ts
+++ b/config/routes.ts
@@ -39,7 +39,7 @@ export default [
       },
       {
         component: '404',
-        path: '/*',
+        path: '/user/*',
       },
     ],
   },


### PR DESCRIPTION
Fixed error: Absolute route path "/*" nested under path "/user" is not valid. An absolute child route path must start with the combined path of all its parent routes.