### PR TITLE
fix: 解决 headScripts 链接与 publicPath 不匹配

### DIFF
--- a/config/config.ts
+++ b/config/config.ts
@@ -7,6 +7,13 @@ import routes from './routes';
 
 const { REACT_APP_ENV = 'dev' } = process.env;
 
+/**
+ * @name 使用公共路径
+ * @description 部署时的路径，如果部署在非根目录下，需要配置这个变量
+ * @doc https://umijs.org/docs/api/config#publicpath
+ */
+const PUBLIC_PATH: string = '/';
+
 export default defineConfig({
   /**
    * @name 开启 hash 模式
@@ -14,6 +21,8 @@ export default defineConfig({
    * @doc https://umijs.org/docs/api/config#hash
    */
   hash: true,
+
+  publicPath: PUBLIC_PATH,
 
   /**
    * @name 兼容性设置
@@ -125,7 +134,7 @@ export default defineConfig({
    */
   headScripts: [
     // 解决首次加载时白屏的问题
-    { src: '/scripts/loading.js', async: true },
+    { src: join(PUBLIC_PATH, 'scripts/loading.js'), async: true },
   ],
   //================ pro 插件配置 =================
   presets: ['umi-presets-pro'],


### PR DESCRIPTION
使用 PUBLIC_PATH 打包好了就会有问题呢，对新同学不太友好。
是否有其他的解法，帮助 scripts/loading.js 添加前缀

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
  - 配置了动态公共路径以支持脚本，使不同部署环境的兼容性更强。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->