### PR TITLE
fix: adjusting workplace project notice card style

### DIFF
--- a/src/pages/dashboard/workplace/index.tsx
+++ b/src/pages/dashboard/workplace/index.tsx
@@ -173,6 +173,9 @@ const Workplace: FC = () => {
                       </div>
                     }
                     description={item.description}
+                    style={{
+                      width: '100%',
+                    }}
                   />
                   <div className={styles.projectItemContent}>
                     <Link to={item.memberLink || '/'}>{item.member || ''}</Link>


### PR DESCRIPTION
| Before | After |
| ------- | ------ |
| ![image](https://github.com/user-attachments/assets/9940be39-dc4d-4a3a-a85f-3a11a69aad70) | ![image](https://github.com/user-attachments/assets/296f1f7c-5621-4b04-a62f-ddb9c8de0598) |

description过短时无法撑开导致布局错位