### PR TITLE
fix: title={false} should work in login page

### DIFF
--- a/src/pages/User/Login/index.tsx
+++ b/src/pages/User/Login/index.tsx
@@ -151,7 +151,7 @@ const Login: React.FC = () => {
             id: 'menu.login',
             defaultMessage: '登录页',
           })}
-          - {Settings.title}
+          {Settings.title && ` - ${Settings.title}`}
         </title>
       </Helmet>
       <Lang />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- 修复了登录组件标题渲染的问题，确保在 `Settings.title` 未定义时不会显示前导连字符。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->