### PR TITLE
chore: remove deprecated deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "antd-style": "^3.7.0",
     "classnames": "^2.5.1",
     "dayjs": "^1.11.13",
-    "querystring": "^0.2.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
@@ -55,9 +54,7 @@
     "@commitlint/config-conventional": "^19.5.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/react": "^16.0.1",
-    "@types/classnames": "^2.3.1",
     "@types/express": "^4.17.21",
-    "@types/history": "^5.0.0",
     "@types/jest": "^29.5.13",
     "@types/lodash": "^4.17.10",
     "@types/react": "^18.3.11",

--- a/src/components/RightContent/AvatarDropdown.tsx
+++ b/src/components/RightContent/AvatarDropdown.tsx
@@ -4,7 +4,6 @@ import { history, useModel } from '@umijs/max';
 import { Spin } from 'antd';
 import type { MenuProps } from 'antd';
 import { createStyles } from 'antd-style';
-import { stringify } from 'querystring';
 import React from 'react';
 import { flushSync } from 'react-dom';
 import HeaderDropdown from '../HeaderDropdown';
@@ -46,15 +45,16 @@ export const AvatarDropdown: React.FC<GlobalHeaderRightProps> = ({ menu, childre
     await outLogin();
     const { search, pathname } = window.location;
     const urlParams = new URL(window.location.href).searchParams;
+    const searchParams = new URLSearchParams({
+      redirect: pathname + search,
+    });
     /** 此方法会跳转到 redirect 参数所在的位置 */
     const redirect = urlParams.get('redirect');
     // Note: There may be security issues, please note
     if (window.location.pathname !== '/user/login' && !redirect) {
       history.replace({
         pathname: '/user/login',
-        search: stringify({
-          redirect: pathname + search,
-        }),
+        search: searchParams.toString(),
       });
     }
   };


### PR DESCRIPTION
WARN  deprecated @types/classnames@2.3.4: This is a stub types definition. classnames provides its own type definitions, so you do not need this installed.
 WARN  deprecated @types/history@5.0.0: This is a stub types definition. history provides its own type definitions, so you do not need this installed.

 WARN  deprecated querystring@0.2.1: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **依赖项更改**
	- 移除了 `querystring` 依赖
	- 移除了 `@types/classnames` 开发依赖
	- 移除了 `@types/history` 开发依赖

- **功能调整**
	- 使用原生 `URLSearchParams` 替代 `querystring` 处理重定向参数
	- 优化注销后的 URL 参数构建方式

<!-- end of auto-generated comment: release notes by coderabbit.ai -->