### PR TITLE
fix: SettingDrawer settings 修改不生效

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -115,7 +115,7 @@ export const layout: RunTimeLayoutConfig = ({ initialState, setInitialState }) =
               onSettingChange={(settings) => {
                 setInitialState((preInitialState) => ({
                   ...preInitialState,
-                  settings,
+                  ...settings,
                 }));
               }}
             />


### PR DESCRIPTION
你好，我发现一个问题，在dev环境，通过 SettingDrawer 进行设置，并没有生效。现在，它已经得到了修复。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **优化**
  - 调整了设置变更时的状态更新方式，提升了设置生效的灵活性和一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->