### PR TITLE
Remove 'react-fittext' module declaration

### DIFF
--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -13,4 +13,3 @@ declare module '*.tiff';
 declare module 'omit.js';
 declare module 'numeral';
 declare module 'mockjs';
-declare module 'react-fittext';


### PR DESCRIPTION
Removed declaration for 'react-fittext' module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 版本发布说明

* **Chores**
  * 移除了不再使用的外部模块类型声明，优化项目依赖管理。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->