### PR TITLE
fix: correct typo 'Desgin' to 'Design' in Footer

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -8,7 +8,7 @@ const Footer: React.FC = () => {
       style={{
         background: 'none',
       }}
-      copyright="Powered by Ant Desgin"
+      copyright="Powered by Ant Design"
       links={[
         {
           key: 'Ant Design Pro',

--- a/src/pages/user/login/__snapshots__/login.test.tsx.snap
+++ b/src/pages/user/login/__snapshots__/login.test.tsx.snap
@@ -535,7 +535,7 @@ exports[`Login Page should login success 1`] = `
                 />
               </svg>
             </span>
-             Powered by Ant Desgin
+             Powered by Ant Design
           </div>
         </div>
       </footer>
@@ -1078,7 +1078,7 @@ exports[`Login Page should show login form 1`] = `
                 />
               </svg>
             </span>
-             Powered by Ant Desgin
+             Powered by Ant Design
           </div>
         </div>
       </footer>


### PR DESCRIPTION
## 问题
修正底部组件中的拼写错误：“Desgin”应改为“Design”

## 变更
- `src/components/Footer/index.tsx`：修正了拼写错误
- 相应地更新了快照测试

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修正页脚显示的拼写错误：将“Powered by Ant Desgin”更正为“Powered by Ant Design”，以提升界面文本准确性并避免对品牌名称的误读。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->