### PR TITLE
fix: support multi-level subdomains in CORS

### DIFF
--- a/cloudflare-worker/src/utils/cors.ts
+++ b/cloudflare-worker/src/utils/cors.ts
@@ -1,6 +1,6 @@
 const allowedPatterns = [
-  /^https:\/\/[\w-]+\.surge\.sh$/,
-  /^https:\/\/[\w-]+\.pages\.dev$/,
+  /^https:\/\/.*\.surge\.sh$/,
+  /^https:\/\/.*\.pages\.dev$/,
   /^https:\/\/preview\.pro\.ant\.design$/,
   /^http:\/\/localhost:\d+$/,
 ];


### PR DESCRIPTION
## Summary
- Fix CORS to support multi-level subdomains like `*.ant-design-pro-nd3.pages.dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 扩展了跨源资源共享 (CORS) 策略，允许更多来自 `surge.sh` 和 `pages.dev` 的源通过验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->