### PR TITLE
chore: group dependabot updates and ignore patch version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,13 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: 'npm' # See documentation for possible values
-    directory: '/' # Location of package manifests
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-patch']
+    groups:
+      dependencies:
+        patterns:
+          - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'daily'
     ignore:
       - dependency-name: '*'
         update-types: ['version-update:semver-patch']


### PR DESCRIPTION
## Summary
- 将所有依赖更新合并为一个 grouped PR，避免每个依赖单独提一个 PR
- 忽略 semver-patch 版本更新（`^` 版本已自动兼容，无需提示）
- 检查频率从 daily 改为 weekly，减少噪音

## Test plan
- [ ] 合并后观察下一次 Dependabot 检查是否只产生一个 grouped PR
- [ ] 确认 patch 版本更新不再生成单独的 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **配置更新**
  * 添加规则：忽略所有依赖的补丁版本自动更新（semver-patch）。
  * 统一依赖分组：将所有匹配项归为同一分组，便于集中管理和审查。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->