### PR TITLE
docs: add GitHub and Stars badges to cheatsheet

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,5 +1,8 @@
 {
-  "**/*.{js,jsx,tsx,ts,md,css,less,json}": [
+  "**/*.{js,jsx,tsx,ts,css,less,json}": [
+    "npx @biomejs/biome check --write"
+  ],
+  "src/**/*.md": [
     "npx @biomejs/biome check --write"
   ]
 }

--- a/docs/cheatsheet.en-US.md
+++ b/docs/cheatsheet.en-US.md
@@ -2,6 +2,8 @@
 
 ![Ant Design Pro](https://mdn.alipayobjects.com/huamei_fkc4p0/afts/img/A*EX3ISYC2ghEAAAAAddAAAAgAeobDAQ/original)
 
+[![GitHub](https://img.shields.io/badge/GitHub-ant--design%2Fant--design--pro-181717?logo=github)](https://github.com/ant-design/ant-design-pro) [![Stars](https://img.shields.io/github/stars/ant-design/ant-design-pro?style=social)](https://github.com/ant-design/ant-design-pro)
+
 ## Getting Started
 
 **Requirements:** Node.js >= 20

--- a/docs/cheatsheet.zh-CN.md
+++ b/docs/cheatsheet.zh-CN.md
@@ -2,6 +2,8 @@
 
 ![Ant Design Pro](https://mdn.alipayobjects.com/huamei_fkc4p0/afts/img/A*EX3ISYC2ghEAAAAAddAAAAgAeobDAQ/original)
 
+[![GitHub](https://img.shields.io/badge/GitHub-ant--design%2Fant--design--pro-181717?logo=github)](https://github.com/ant-design/ant-design-pro) [![Stars](https://img.shields.io/github/stars/ant-design/ant-design-pro?style=social)](https://github.com/ant-design/ant-design-pro)
+
 ## 快速开始
 
 **环境要求：** Node.js >= 20


### PR DESCRIPTION
## Summary

- 在 cheatsheet（zh-CN / en-US）顶部 banner 下方添加 GitHub 仓库链接 badge 和 Stars 数 badge（使用 shields.io）
- 修复 `.lintstagedrc` 配置，排除 `docs/` 下的 `.md` 文件（biome 不处理这些文件，此前会导致 pre-commit hook 失败）

## Test plan

- [ ] 本地启动项目，访问 Welcome 页面确认 badge 正常渲染
- [ ] 确认 badge 点击可跳转到 GitHub 仓库
- [ ] 确认 Stars badge 动态展示当前 star 数

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **文档**
  * 在速查表文档中添加了 GitHub 仓库徽章和星标链接，方便用户快速访问项目 GitHub 页面。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->