### PR TITLE
fix: preserve original URL when redirecting to login

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -41,7 +41,13 @@ export async function getInitialState(): Promise<{
       });
       return msg.data;
     } catch (_error) {
-      history.push(loginPath);
+      history.push(
+        loginPath +
+          '?redirect=' +
+          encodeURIComponent(
+            history.location.pathname + history.location.search,
+          ),
+      );
     }
     return undefined;
   };
@@ -100,7 +106,11 @@ export const layout: RunTimeLayoutConfig = ({
       const { location } = history;
       // 如果没有登录，重定向到 login
       if (!initialState?.currentUser && location.pathname !== loginPath) {
-        history.push(loginPath);
+        history.push(
+          loginPath +
+            '?redirect=' +
+            encodeURIComponent(location.pathname + location.search),
+        );
       }
     },
     bgLayoutImgList: [

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -41,12 +41,9 @@ export async function getInitialState(): Promise<{
       });
       return msg.data;
     } catch (_error) {
-      history.push(
-        loginPath +
-          '?redirect=' +
-          encodeURIComponent(
-            history.location.pathname + history.location.search,
-          ),
+      const { pathname, search, hash } = history.location;
+      history.replace(
+        `${loginPath}?redirect=${encodeURIComponent(pathname + search + hash)}`,
       );
     }
     return undefined;
@@ -106,10 +103,8 @@ export const layout: RunTimeLayoutConfig = ({
       const { location } = history;
       // 如果没有登录，重定向到 login
       if (!initialState?.currentUser && location.pathname !== loginPath) {
-        history.push(
-          loginPath +
-            '?redirect=' +
-            encodeURIComponent(location.pathname + location.search),
+        history.replace(
+          `${loginPath}?redirect=${encodeURIComponent(location.pathname + location.search + location.hash)}`,
         );
       }
     },


### PR DESCRIPTION
## Summary

- 未认证用户访问受保护页面时，重定向到登录页现在会携带 `redirect` 查询参数，保留用户原始访问的 URL
- 修复了 `getInitialState()` 和 `onPageChange()` 中 `history.push(loginPath)` 没有传入原始页面地址的问题
- 登录页已有读取 `redirect` 参数并跳转回原页面的逻辑（`getSafeRedirectUrl`），登出流程也已正确传递 `redirect`，此次修复补齐了未认证访问场景的逻辑

## Test plan

- [ ] 直接访问 `/account/center` 等受保护页面，应跳转到 `/user/login?redirect=%2Faccount%2Fcenter`
- [ ] 登录成功后，应自动跳转回原始页面
- [ ] 带查询参数的页面（如 `/account/center?tab=settings`），redirect 应包含完整路径和查询参数
- [ ] 正常登录（从登录页直接登录）仍应跳转到首页
- [ ] 登出后重新登录仍能正确跳转回当前页面

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **错误修复**
  * 改进了身份验证流程中的重定向处理，确保用户登录后能正确返回到原始请求的页面。
  * 优化了浏览器历史记录管理，防止身份验证期间产生不必要的历史记录条目，改善用户的浏览体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->