### PR TITLE
feat: 在右上角头像菜单添加历史版本链接

### DIFF
--- a/src/components/RightContent/AvatarDropdown.tsx
+++ b/src/components/RightContent/AvatarDropdown.tsx
@@ -2,6 +2,7 @@ import {
   BookOutlined,
   CheckOutlined,
   GlobalOutlined,
+  HistoryOutlined,
   LogoutOutlined,
   SettingOutlined,
   SkinOutlined,
@@ -73,6 +74,11 @@ export const AvatarDropdown: React.FC<GlobalHeaderRightProps> = ({
       setLocale(key.replace('lang-', ''), false);
       return;
     }
+    if (key.startsWith('version-')) {
+      const url = key.replace('version-', '');
+      window.open(url, '_blank');
+      return;
+    }
     history.push(`/account/${key}`);
   };
 
@@ -107,6 +113,29 @@ export const AvatarDropdown: React.FC<GlobalHeaderRightProps> = ({
       key: 'doc',
       icon: <BookOutlined />,
       label: '使用文档',
+    },
+    {
+      key: 'version',
+      icon: <HistoryOutlined />,
+      label: '历史版本',
+      children: [
+        {
+          key: 'version-https://v5.pro.ant.design',
+          label: 'v5',
+        },
+        {
+          key: 'version-https://v4.pro.ant.design',
+          label: 'v4',
+        },
+        {
+          key: 'version-https://v2.pro.ant.design',
+          label: 'v2',
+        },
+        {
+          key: 'version-https://v1.pro.ant.design',
+          label: 'v1',
+        },
+      ],
     },
     ...(supportLocales.length > 1
       ? [

--- a/src/components/RightContent/AvatarDropdown.tsx
+++ b/src/components/RightContent/AvatarDropdown.tsx
@@ -76,7 +76,7 @@ export const AvatarDropdown: React.FC<GlobalHeaderRightProps> = ({
     }
     if (key.startsWith('version-')) {
       const url = key.replace('version-', '');
-      window.open(url, '_blank');
+      window.open(url, '_blank', 'noopener,noreferrer');
       return;
     }
     history.push(`/account/${key}`);

--- a/src/components/RightContent/AvatarDropdown.tsx
+++ b/src/components/RightContent/AvatarDropdown.tsx
@@ -12,6 +12,7 @@ import {
   getLocale,
   history,
   setLocale,
+  useIntl,
   useModel,
 } from '@umijs/max';
 import type { MenuProps } from 'antd';
@@ -52,6 +53,7 @@ export const AvatarDropdown: React.FC<GlobalHeaderRightProps> = ({
     }
   };
   const { initialState, setInitialState } = useModel('@@initialState');
+  const intl = useIntl();
 
   const onMenuClick: MenuProps['onClick'] = (event) => {
     const { key } = event;
@@ -117,7 +119,9 @@ export const AvatarDropdown: React.FC<GlobalHeaderRightProps> = ({
     {
       key: 'version',
       icon: <HistoryOutlined />,
-      label: '历史版本',
+      label: intl.formatMessage({
+        id: 'component.globalHeader.historyVersion',
+      }),
       children: [
         {
           key: 'version-https://v5.pro.ant.design',

--- a/src/locales/en-US/globalHeader.ts
+++ b/src/locales/en-US/globalHeader.ts
@@ -4,6 +4,7 @@ export default {
   'component.globalHeader.search.example2': 'Search example 2',
   'component.globalHeader.search.example3': 'Search example 3',
   'component.globalHeader.help': 'Help',
+  'component.globalHeader.historyVersion': 'Previous Versions',
   'component.globalHeader.notification': 'Notification',
   'component.globalHeader.notification.empty':
     'You have viewed all notifications.',

--- a/src/locales/zh-CN/globalHeader.ts
+++ b/src/locales/zh-CN/globalHeader.ts
@@ -4,6 +4,7 @@ export default {
   'component.globalHeader.search.example2': '搜索提示二',
   'component.globalHeader.search.example3': '搜索提示三',
   'component.globalHeader.help': '使用文档',
+  'component.globalHeader.historyVersion': '历史版本',
   'component.globalHeader.notification': '通知',
   'component.globalHeader.notification.empty': '你已查看所有通知',
   'component.globalHeader.message': '消息',

--- a/src/locales/zh-TW/globalHeader.ts
+++ b/src/locales/zh-TW/globalHeader.ts
@@ -4,6 +4,7 @@ export default {
   'component.globalHeader.search.example2': '搜索提示二',
   'component.globalHeader.search.example3': '搜索提示三',
   'component.globalHeader.help': '使用手冊',
+  'component.globalHeader.historyVersion': '歷史版本',
   'component.globalHeader.notification': '通知',
   'component.globalHeader.notification.empty': '妳已查看所有通知',
   'component.globalHeader.message': '消息',


### PR DESCRIPTION
## Summary

- 在 AvatarDropdown 头像下拉菜单中新增「历史版本」子菜单
- 包含 v5、v4、v2、v1 四个版本站点链接（v3 无对应站点已移除）
- 点击版本链接在新标签页打开对应站点

## Test plan

- [ ] 点击右上角头像，确认下拉菜单中出现「历史版本」子菜单
- [ ] 点击各版本链接，确认在新标签页打开正确的站点地址
- [ ] 确认其他菜单项（个人设置、主题设置、语言切换、退出登录）功能正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发版说明

* **新功能**
  * 头像下拉菜单新增“历史版本”分组，展示按版本列出的外部链接，便于快速访问过去发布内容。
  * 选择历史版本项将直接在新浏览器标签页打开对应外部链接（使用 noopener,noreferrer 等安全选项），不会触发原有的账号/导航流程。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->