### PR TITLE
chore: update README badges, links, and outdated content

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An out-of-box UI solution for enterprise applications as a React boilerplate.
 
 [![CI](https://github.com/ant-design/ant-design-pro/actions/workflows/ci.yml/badge.svg)](https://github.com/ant-design/ant-design-pro/actions/workflows/ci.yml)
 [![Build With Utoo](https://img.shields.io/badge/build%20with-utoo-028fe4.svg?style=flat-square)](https://utoo.land)
-[![Build With Umi](https://img.shields.io/badge/build%20with-umi-028fe4.svg?style=flat-square)](http://umijs.org/)
+[![Build With Umi](https://img.shields.io/badge/build%20with-umi-028fe4.svg?style=flat-square)](https://umijs.org/)
 [![Checked with Biome](https://img.shields.io/badge/Checked_with-Biome-60a5fa?style=flat&logo=biome)](https://biomejs.dev)
 [![](https://badgen.net/badge/icon/Ant%20Design?icon=https://gw.alipayobjects.com/zos/antfincdn/Pp4WPgVDB3/KDpgvguMpGfqaHPjicRK.svg&label)](https://ant.design/)
 
@@ -17,7 +17,7 @@ Language: 🇺🇸 | [🇨🇳](./README.zh-CN.md)
 
 </div>
 
-- Preview: http://preview.pro.ant.design
+- Preview: https://preview.pro.ant.design
 - Documentation: [docs/cheatsheet.en-US.md](./docs/cheatsheet.en-US.md)
 - ChangeLog: https://github.com/ant-design/ant-design-pro/releases
 - FAQ: [docs/cheatsheet.en-US.md#faq](./docs/cheatsheet.en-US.md#faq)
@@ -26,9 +26,9 @@ Language: 🇺🇸 | [🇨🇳](./README.zh-CN.md)
 
 - :bulb: **TypeScript**: A language for application-scale JavaScript
 - :scroll: **Blocks**: Build page with block template
-- :gem: **Neat Design**: Follow [Ant Design specification](http://ant.design/)
+- :gem: **Neat Design**: Follow [Ant Design specification](https://ant.design/)
 - :triangular_ruler: **Common Templates**: Typical templates for enterprise applications
-- :rocket: **State of The Art Development**: Newest development stack of React/umi/dva/antd
+- :rocket: **State of The Art Development**: Newest development stack of React/umi/dva/antd/utoo
 - :iphone: **Responsive**: Designed for variable screen sizes
 - :art: **Theming**: Customizable theme with simple config
 - :globe_with_meridians: **International**: Built-in i18n solution

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ Language: 🇺🇸 | [🇨🇳](./README.zh-CN.md)
 
 - :bulb: **TypeScript**: A language for application-scale JavaScript
 - :scroll: **Blocks**: Build page with block template
-- :gem: **Neat Design**: Follow [Ant Design specification](https://ant.design/)
+- :gem: **Neat Design**: Built on [Ant Design 6](https://ant.design/) specification
 - :triangular_ruler: **Common Templates**: Typical templates for enterprise applications
-- :rocket: **State of The Art Development**: Newest development stack of React/umi/antd/utoo
+- :rocket: **State of The Art Development**: Newest development stack of React 19/[umi](https://umijs.org/)/[antd 6](https://ant.design/)/[utoo](https://utoo.land)
 - :iphone: **Responsive**: Designed for variable screen sizes
-- :art: **Theming**: Customizable theme with simple config
+- :art: **Theming**: Customizable theme with [antd-style](https://github.com/ant-design/antd-style)
 - :globe_with_meridians: **International**: Built-in i18n solution
 - :gear: **Best Practices**: Solid workflow to make your code healthy
 - :1234: **Mock development**: Easy to use mock development solution

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Language: 🇺🇸 | [🇨🇳](./README.zh-CN.md)
 - :scroll: **Blocks**: Build page with block template
 - :gem: **Neat Design**: Follow [Ant Design specification](https://ant.design/)
 - :triangular_ruler: **Common Templates**: Typical templates for enterprise applications
-- :rocket: **State of The Art Development**: Newest development stack of React/umi/dva/antd/utoo
+- :rocket: **State of The Art Development**: Newest development stack of React/umi/antd/utoo
 - :iphone: **Responsive**: Designed for variable screen sizes
 - :art: **Theming**: Customizable theme with simple config
 - :globe_with_meridians: **International**: Built-in i18n solution

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 An out-of-box UI solution for enterprise applications as a React boilerplate.
 
 [![CI](https://github.com/ant-design/ant-design-pro/actions/workflows/ci.yml/badge.svg)](https://github.com/ant-design/ant-design-pro/actions/workflows/ci.yml)
-[![Preview Deploy](https://github.com/ant-design/ant-design-pro/actions/workflows/preview-deploy.yml/badge.svg)](https://github.com/ant-design/ant-design-pro/actions/workflows/preview-deploy.yml)
+[![Build With Utoo](https://img.shields.io/badge/build%20with-utoo-028fe4.svg?style=flat-square)](https://utoo.land)
 [![Build With Umi](https://img.shields.io/badge/build%20with-umi-028fe4.svg?style=flat-square)](http://umijs.org/)
 [![Checked with Biome](https://img.shields.io/badge/Checked_with-Biome-60a5fa?style=flat&logo=biome)](https://biomejs.dev)
 [![](https://badgen.net/badge/icon/Ant%20Design?icon=https://gw.alipayobjects.com/zos/antfincdn/Pp4WPgVDB3/KDpgvguMpGfqaHPjicRK.svg&label)](https://ant.design/)

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 An out-of-box UI solution for enterprise applications as a React boilerplate.
 
 [![CI](https://github.com/ant-design/ant-design-pro/actions/workflows/ci.yml/badge.svg)](https://github.com/ant-design/ant-design-pro/actions/workflows/ci.yml)
-[![Build With Utoo](https://img.shields.io/badge/build%20with-utoo-028fe4.svg?style=flat-square)](https://utoo.land)
-[![Build With Umi](https://img.shields.io/badge/build%20with-umi-028fe4.svg?style=flat-square)](https://umijs.org/)
+[![Build With Utoo](https://img.shields.io/badge/build%20with-utoo-028fe4.svg)](https://utoo.land)
+[![Build With Umi](https://img.shields.io/badge/build%20with-umi-028fe4.svg)](https://umijs.org/)
 [![Checked with Biome](https://img.shields.io/badge/Checked_with-Biome-60a5fa?style=flat&logo=biome)](https://biomejs.dev)
-[![](https://badgen.net/badge/icon/Ant%20Design?icon=https://gw.alipayobjects.com/zos/antfincdn/Pp4WPgVDB3/KDpgvguMpGfqaHPjicRK.svg&label)](https://ant.design/)
+[![Ant Design](https://badgen.net/badge/icon/Ant%20Design?icon=https://gw.alipayobjects.com/zos/antfincdn/Pp4WPgVDB3/KDpgvguMpGfqaHPjicRK.svg&label)](https://ant.design/)
 
 Language: 🇺🇸 | [🇨🇳](./README.zh-CN.md)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,10 +7,10 @@ Language : [🇺🇸](./README.md) | 🇨🇳
 开箱即用的中台前端/设计解决方案。
 
 [![CI](https://github.com/ant-design/ant-design-pro/actions/workflows/ci.yml/badge.svg)](https://github.com/ant-design/ant-design-pro/actions/workflows/ci.yml)
-[![Build With Utoo](https://img.shields.io/badge/build%20with-utoo-028fe4.svg?style=flat-square)](https://utoo.land)
-[![Build With Umi](https://img.shields.io/badge/build%20with-umi-028fe4.svg?style=flat-square)](https://umijs.org/)
+[![Build With Utoo](https://img.shields.io/badge/build%20with-utoo-028fe4.svg)](https://utoo.land)
+[![Build With Umi](https://img.shields.io/badge/build%20with-umi-028fe4.svg)](https://umijs.org/)
 [![Checked with Biome](https://img.shields.io/badge/Checked_with-Biome-60a5fa?style=flat&logo=biome)](https://biomejs.dev)
-[![](https://badgen.net/badge/icon/Ant%20Design?icon=https://gw.alipayobjects.com/zos/antfincdn/Pp4WPgVDB3/KDpgvguMpGfqaHPjicRK.svg&label)](https://ant.design/)
+[![Ant Design](https://badgen.net/badge/icon/Ant%20Design?icon=https://gw.alipayobjects.com/zos/antfincdn/Pp4WPgVDB3/KDpgvguMpGfqaHPjicRK.svg&label)](https://ant.design/)
 
 ![](https://github.com/user-attachments/assets/fde29061-3d9a-4397-8ac2-397b0e033ef5)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,22 +8,18 @@ Language : [🇺🇸](./README.md) | 🇨🇳
 
 [![CI](https://github.com/ant-design/ant-design-pro/actions/workflows/ci.yml/badge.svg)](https://github.com/ant-design/ant-design-pro/actions/workflows/ci.yml)
 [![Build With Utoo](https://img.shields.io/badge/build%20with-utoo-028fe4.svg?style=flat-square)](https://utoo.land)
-[![Build With Umi](https://img.shields.io/badge/build%20with-umi-028fe4.svg?style=flat-square)](http://umijs.org/)
+[![Build With Umi](https://img.shields.io/badge/build%20with-umi-028fe4.svg?style=flat-square)](https://umijs.org/)
 [![Checked with Biome](https://img.shields.io/badge/Checked_with-Biome-60a5fa?style=flat&logo=biome)](https://biomejs.dev)
-![](https://badgen.net/badge/icon/Ant%20Design?icon=https://gw.alipayobjects.com/zos/antfincdn/Pp4WPgVDB3/KDpgvguMpGfqaHPjicRK.svg&label)
+[![](https://badgen.net/badge/icon/Ant%20Design?icon=https://gw.alipayobjects.com/zos/antfincdn/Pp4WPgVDB3/KDpgvguMpGfqaHPjicRK.svg&label)](https://ant.design/)
 
 ![](https://github.com/user-attachments/assets/fde29061-3d9a-4397-8ac2-397b0e033ef5)
 
 </div>
 
-- 预览：http://preview.pro.ant.design
+- 预览：https://preview.pro.ant.design
 - 使用文档：[docs/cheatsheet.zh-CN.md](./docs/cheatsheet.zh-CN.md)
 - 更新日志: https://github.com/ant-design/ant-design-pro/releases
 - 常见问题：[docs/cheatsheet.zh-CN.md#faq](./docs/cheatsheet.zh-CN.md#faq)
-
-## 5.0 已经发布! 🎉🎉🎉
-
-[Ant Design Pro 5.0](https://github.com/ant-design/ant-design-pro/issues/8656)
 
 ## 特性
 
@@ -31,7 +27,7 @@ Language : [🇺🇸](./README.md) | 🇨🇳
 - :scroll: **区块**: 通过区块模板快速构建页面
 - :gem: **优雅美观**：基于 Ant Design 体系精心设计
 - :triangular_ruler: **常见设计模式**：提炼自中后台应用的典型页面和场景
-- :rocket: **最新技术栈**：使用 React/umi/dva/antd 等前端前沿技术开发
+- :rocket: **最新技术栈**：使用 React/umi/dva/antd/utoo 等前端前沿技术开发
 - :iphone: **响应式**：针对不同屏幕大小设计
 - :art: **主题**：可配置的主题满足多样化的品牌诉求
 - :globe_with_meridians: **国际化**：内建业界通用的国际化方案

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,7 +7,7 @@ Language : [🇺🇸](./README.md) | 🇨🇳
 开箱即用的中台前端/设计解决方案。
 
 [![CI](https://github.com/ant-design/ant-design-pro/actions/workflows/ci.yml/badge.svg)](https://github.com/ant-design/ant-design-pro/actions/workflows/ci.yml)
-[![Preview Deploy](https://github.com/ant-design/ant-design-pro/actions/workflows/preview-deploy.yml/badge.svg)](https://github.com/ant-design/ant-design-pro/actions/workflows/preview-deploy.yml)
+[![Build With Utoo](https://img.shields.io/badge/build%20with-utoo-028fe4.svg?style=flat-square)](https://utoo.land)
 [![Build With Umi](https://img.shields.io/badge/build%20with-umi-028fe4.svg?style=flat-square)](http://umijs.org/)
 [![Checked with Biome](https://img.shields.io/badge/Checked_with-Biome-60a5fa?style=flat&logo=biome)](https://biomejs.dev)
 ![](https://badgen.net/badge/icon/Ant%20Design?icon=https://gw.alipayobjects.com/zos/antfincdn/Pp4WPgVDB3/KDpgvguMpGfqaHPjicRK.svg&label)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -27,7 +27,7 @@ Language : [🇺🇸](./README.md) | 🇨🇳
 - :scroll: **区块**: 通过区块模板快速构建页面
 - :gem: **优雅美观**：基于 Ant Design 体系精心设计
 - :triangular_ruler: **常见设计模式**：提炼自中后台应用的典型页面和场景
-- :rocket: **最新技术栈**：使用 React/umi/dva/antd/utoo 等前端前沿技术开发
+- :rocket: **最新技术栈**：使用 React/umi/antd/utoo 等前端前沿技术开发
 - :iphone: **响应式**：针对不同屏幕大小设计
 - :art: **主题**：可配置的主题满足多样化的品牌诉求
 - :globe_with_meridians: **国际化**：内建业界通用的国际化方案

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -25,11 +25,11 @@ Language : [🇺🇸](./README.md) | 🇨🇳
 
 - :bulb: **TypeScript**: 应用程序级 JavaScript 的语言
 - :scroll: **区块**: 通过区块模板快速构建页面
-- :gem: **优雅美观**：基于 Ant Design 体系精心设计
+- :gem: **优雅美观**：基于 [Ant Design 6](https://ant.design/) 体系精心设计
 - :triangular_ruler: **常见设计模式**：提炼自中后台应用的典型页面和场景
-- :rocket: **最新技术栈**：使用 React/umi/antd/utoo 等前端前沿技术开发
+- :rocket: **最新技术栈**：使用 React 19/[umi](https://umijs.org/)/[antd 6](https://ant.design/)/[utoo](https://utoo.land) 等前端前沿技术开发
 - :iphone: **响应式**：针对不同屏幕大小设计
-- :art: **主题**：可配置的主题满足多样化的品牌诉求
+- :art: **主题**：基于 [antd-style](https://github.com/ant-design/antd-style) 的可配置主题满足多样化品牌诉求
 - :globe_with_meridians: **国际化**：内建业界通用的国际化方案
 - :gear: **最佳实践**：良好的工程实践助您持续产出高质量代码
 - :1234: **Mock 数据**：实用的本地数据调试方案


### PR DESCRIPTION
## Summary
- Replace Preview Deploy badge with Utoo badge
- Add utoo to tech stack in Features
- Fix Ant Design badge link in Chinese README
- Remove outdated "5.0 release" section from Chinese README
- Upgrade HTTP links to HTTPS (preview, umijs, ant.design)

## Test plan
- [ ] Verify badges display correctly in README.md and README.zh-CN.md
- [ ] Verify all links are accessible and redirect properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **文档**
  * 更新 README（中/英）徽章与链接：移除预览部署徽章，新增“Build With Utoo”徽章，若干链接升级为 HTTPS，Ant Design 徽标改为可点击的链接徽章，预览链接改为 HTTPS。
  * 调整文档内容：删除“5.0 已经发布”公告，更新“最新技术栈”为 React 19 / umi / antd 6 / utoo，说明“优雅美观”指向 Ant Design 6，“主题”改为 antd-style。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->