### PR TITLE
fix: footer version extra quotes, add Umi/Utoo versions and commit hash fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,145 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Ant Design Pro — an enterprise-class React UI solution built on Umi Max (v4), antd v6, and ProComponents v3. It serves as both a production boilerplate and a live demo of Ant Design's capabilities.
+
+## Commands
+
+```bash
+# Development
+npm start              # Dev server with mock (UMI_ENV=dev)
+npm run dev            # Dev server without mock
+npm run start:no-mock  # Start with MOCK=none, proxy to real backend
+npm run start:pre      # Pre-production environment
+npm run start:test     # Test environment
+
+# Build & Preview
+npm run build          # Production build (utoopack, Turbopack-based)
+npm run preview        # Preview production build on port 8000
+npm run preview:build  # Build and preview on port 8000
+npm run deploy         # Build and deploy to GitHub Pages (gh-pages branch)
+npm run analyze        # Bundle size analysis
+
+# Lint & Type Check
+npm run lint           # Biome lint + tsc --noEmit
+npm run biome          # Biome check --write (auto-fix)
+npm run tsc            # Type check only (tsc --noEmit)
+
+# Test
+npm run test              # Run all Jest tests
+npm run test:coverage     # Jest with coverage
+npm run test:update       # Update test snapshots
+# Run a single test: npx jest src/pages/user/login/login.test.tsx
+
+# Code Generation
+npm run openapi    # Regenerate services from config/oneapi.json (overwrites src/services/)
+
+# Other
+npm run simple     # Irreversible: removes most page blocks for minimal version
+npm run i18n-remove # Remove i18n, replace with zh-CN
+npm run record     # Record request data for mock replay
+```
+
+## Documentation
+
+- `docs/cheatsheet.zh-CN.md` / `docs/cheatsheet.en-US.md` — comprehensive cheatsheet covering routes, layout, data flow, requests, permissions, i18n, styling, and testing with code examples. Rendered in the Welcome page via `@ant-design/x-markdown`.
+
+## Architecture
+
+### Framework: Umi Max
+
+Umi Max (`@umijs/max`) is the meta-framework. It wraps the build pipeline and provides conventions:
+
+- **Build tool**: utoopack (Turbopack-based, Webpack-compatible). Configured via `utoopack` field in `config/config.ts`, supports `module.rules` for custom loaders
+- **Central config**: `config/config.ts` (defineConfig) controls all plugins, theme, proxy, and build settings
+- **Routes**: Defined declaratively in `config/routes.ts`, not convention-based. Each route maps `component` to a file under `src/pages/`. Route `name` auto-maps to `menu.xxx` i18n key. Route `access` field controls menu visibility (unauthorized routes hidden from menu)
+- **Convention files in `src/`**: `app.tsx` (runtime config), `access.ts` (permissions), `global.tsx` (side effects), `loading.tsx` (route transitions), `typings.d.ts` (global types)
+- **Umi plugins** are enabled via config flags in `config/config.ts` (e.g., `model`, `initialState`, `access`, `locale`, `qiankun`)
+
+### Authentication Flow
+
+1. `app.tsx` exports `getInitialState()` → calls `GET /api/currentUser`
+2. If 401 and not on login page → redirect to `/user/login?redirect=...`
+3. `access.ts` defines permissions: `canAdmin` = `currentUser.access === 'admin'`
+4. Routes use `access: 'canAdmin'` in `config/routes.ts` for permission gating
+5. Login mock credentials: `admin`/`ant.design` (admin) or `user`/`ant.design` (user)
+
+### API & Request Layer
+
+- **Auto-generated services** in `src/services/ant-design-pro/` — do NOT edit manually; regenerate with `npm run openapi`
+- **Per-page services**: many pages have co-located `service.ts` files
+- **Request config**: centralized in `src/requestErrorConfig.ts` (error handler, interceptors, base URL). The `request` export in `app.tsx` sets global `RequestConfig`
+- Built-in `request` function from `@umijs/max` — no manual axios wrapping needed
+- Production API: `https://pro-api.ant-design-demo.workers.dev`
+- Dev proxy config: `config/proxy.ts` (keyed by `UMI_ENV`)
+
+### Mock System
+
+- Global mocks in `mock/` (Express-style handlers matching URL patterns like `'GET /api/currentUser'`)
+- Co-located page mocks: `src/pages/**/_mock.ts` (Umi auto-discovers these)
+- `requestRecord.mock.js` is gitignored
+
+### State Management
+
+- **Umi model plugin** (`useModel`): files in `src/models/` auto-register as global hooks. Use `useModel('filename')` in any component
+- **`useModel('@@initialState')`** for global state (currentUser, settings). Initialized by `getInitialState()` in `app.tsx` which runs once on app startup
+- **`useRequest`** from `@umijs/max` for simple data fetching
+- **@tanstack/react-query** for complex server state (e.g., table-list uses `useMutation` + `useQuery`)
+- Most pages use ProTable's built-in `request` prop for data loading
+
+### Styling: Three Systems Coexist
+
+1. **Tailwind CSS v4** — entry: `src/tailwind.css`, PostCSS plugin in `postcss.config.js`. Best for layout utilities
+2. **antd-style v4** (`createStyles`) — CSS-in-JS with design token access (`{ token }`). Preferred when consuming theme tokens
+3. **CSS Modules** (`*.module.less` / `*.module.css`) — for component-scoped styles
+4. **Less** (`global.less`) — legacy, only for font-face declarations and base styles
+
+New code should prefer Tailwind for layout, antd-style for theme-aware styles, CSS Modules for component styles. Less is only for legacy global styles.
+
+Dynamic theme: configured in `config/config.ts` under `antd.configProvider.theme.token`. Dev mode `SettingDrawer` allows live theme switching.
+
+### Internationalization
+
+8 locales in `src/locales/` (zh-CN, en-US, zh-TW, ja-JP, pt-BR, id-ID, fa-IR, bn-BD). Pages use `useIntl().formatMessage()` with `id` and `defaultMessage`. Menu labels auto-resolve via route `name` key (e.g., `name: 'login'` → `menu.login`).
+
+### Layout
+
+ProLayout is configured via the `layout` export in `src/app.tsx` (`RunTimeLayoutConfig`). Layout settings (theme, color, layout mode) in `config/defaultSettings.ts`. Layout modes: `side` (sidebar), `top` (top nav), `mix` (mixed). Routes with `layout: false` (e.g., `/user/*`) render without the ProLayout shell. Use `<PageContainer>` from `@ant-design/pro-components` for page-level headers and breadcrumbs.
+
+### Page Co-location Pattern
+
+Each page directory contains its own `index.tsx`, optional `service.ts`, `_mock.ts`, `data.d.ts` (types), and `style.style.ts` or CSS files. This is the primary organizational pattern — keep page-specific code with the page.
+
+### Cloudflare Worker Backend
+
+`cloudflare-worker/` is a separate deployable (Hono framework, own `package.json`/`tsconfig.json`). Not an npm workspace — manage independently. Provides the production demo API.
+
+## Ant Design CLI
+
+`@ant-design/cli` (antd) is installed as a dev dependency. It provides offline antd component metadata and project analysis. Run via `npx antd`.
+
+- **Always query before writing antd code** — use `npx antd info <Component>` to check props/APIs rather than guessing from memory
+- `npx antd demo <Component> <name>` — get working demo code
+- `npx antd token <Component>` — check design tokens
+- `npx antd semantic <Component>` — check semantic classNames
+- `npx antd lint ./src` — find deprecated or problematic antd usage
+- `npx antd doctor` — diagnose project configuration issues
+- `npx antd migrate <v1> <v2>` — migration checklist between versions
+- Always use `--format json` for structured output
+
+The CLI also supports MCP server mode: `npx antd mcp` (for IDE integrations).
+
+## Key Conventions
+
+- **Biome** replaces ESLint + Prettier. Config in `biome.json`. Pre-commit hook runs `lint-staged` with Biome.
+- **Commit messages**: must follow conventional commits (`commitlint` with `@commitlint/config-conventional`).
+- **TypeScript strict mode** enabled. Path aliases: `@/*` → `./src/*`, `@@/*` → `./src/.umi/*`.
+- **Node >= 20** required.
+- **Markdown as raw strings**: `config/md-raw-loader.cjs` lets `.md` files be imported as strings (used in Welcome/cheatsheet pages with `@ant-design/x-markdown`).
+- **Auto-generated code in `src/services/`** is excluded from Biome linting. Never edit manually — regenerate with `npm run openapi`.
+- **Adding a new page**: 1) Create component in `src/pages/` 2) Add route in `config/routes.ts` 3) Add menu translation in `src/locales/` (route `name` maps to `menu.xxx` i18n key)
+- **Adding global state**: Create a file in `src/models/` exporting a custom Hook, use `useModel('filename')` in components
+- **Access control**: Route-level via `access` field in routes; component-level via `<Access accessible={...}>` or `useAccess()` hook from `@umijs/max`

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 An out-of-box UI solution for enterprise applications as a React boilerplate.
 
 [![CI](https://github.com/ant-design/ant-design-pro/actions/workflows/ci.yml/badge.svg)](https://github.com/ant-design/ant-design-pro/actions/workflows/ci.yml)
+[![GitHub release](https://img.shields.io/github/v/release/ant-design/ant-design-pro.svg)](https://github.com/ant-design/ant-design-pro/releases)
 [![Build With Utoo](https://img.shields.io/badge/build%20with-utoo-028fe4.svg)](https://utoo.land)
 [![Build With Umi](https://img.shields.io/badge/build%20with-umi-028fe4.svg)](https://umijs.org/)
 [![Checked with Biome](https://img.shields.io/badge/Checked_with-Biome-60a5fa?style=flat&logo=biome)](https://biomejs.dev)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,6 +7,7 @@ Language : [🇺🇸](./README.md) | 🇨🇳
 开箱即用的中台前端/设计解决方案。
 
 [![CI](https://github.com/ant-design/ant-design-pro/actions/workflows/ci.yml/badge.svg)](https://github.com/ant-design/ant-design-pro/actions/workflows/ci.yml)
+[![GitHub release](https://img.shields.io/github/v/release/ant-design/ant-design-pro.svg)](https://github.com/ant-design/ant-design-pro/releases)
 [![Build With Utoo](https://img.shields.io/badge/build%20with-utoo-028fe4.svg)](https://utoo.land)
 [![Build With Umi](https://img.shields.io/badge/build%20with-umi-028fe4.svg)](https://umijs.org/)
 [![Checked with Biome](https://img.shields.io/badge/Checked_with-Biome-60a5fa?style=flat&logo=biome)](https://biomejs.dev)

--- a/config/config.ts
+++ b/config/config.ts
@@ -9,6 +9,21 @@ import routes from './routes';
 
 const { UMI_ENV = 'dev' } = process.env;
 
+// Compute commit hash: env vars take precedence, fall back to git at build time
+const commitHash =
+  process.env.COMMIT_HASH ||
+  process.env.CF_PAGES_COMMIT_SHA ||
+  (() => {
+    try {
+      return require('child_process')
+        .execSync('git rev-parse HEAD')
+        .toString()
+        .trim();
+    } catch {
+      return '';
+    }
+  })();
+
 /**
  * @name 使用公共路径
  * @description 部署时的路径，如果部署在非根目录下，需要配置这个变量
@@ -207,8 +222,9 @@ export default defineConfig({
   exportStatic: {},
   define: {
     'process.env.CI': process.env.CI,
-    'process.env.COMMIT_HASH': process.env.COMMIT_HASH || '',
-    'process.env.CF_PAGES_COMMIT_SHA': process.env.CF_PAGES_COMMIT_SHA || '',
-    __APP_VERSION__: JSON.stringify(require('./../package.json').version),
+    'process.env.COMMIT_HASH': commitHash,
+    __APP_VERSION__: require('./../package.json').version,
+    __UMI_VERSION__: require('@umijs/max/package.json').version,
+    __UTOO_VERSION__: require('@utoo/pack/package.json').version,
   },
 });

--- a/config/config.ts
+++ b/config/config.ts
@@ -16,8 +16,10 @@ const commitHash =
   (() => {
     try {
       return require('child_process')
-        .execSync('git rev-parse HEAD')
-        .toString()
+        .execSync('git rev-parse HEAD', {
+          stdio: ['ignore', 'pipe', 'ignore'],
+          encoding: 'utf-8',
+        })
         .trim();
     } catch {
       return '';

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,7 +1,10 @@
-import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { configUmiAlias, createConfig } from '@umijs/max/test.js';
 
-const require = createRequire(import.meta.url);
+const readPkgVersion = (pkg: string) =>
+  JSON.parse(readFileSync(join('node_modules', pkg, 'package.json'), 'utf-8'))
+    .version;
 
 export default async (): Promise<any> => {
   const config = await configUmiAlias({
@@ -26,8 +29,8 @@ export default async (): Promise<any> => {
       ...config.globals,
       localStorage: null,
       __APP_VERSION__: 'test',
-      __UMI_VERSION__: require('@umijs/max/package.json').version,
-      __UTOO_VERSION__: require('@utoo/pack/package.json').version,
+      __UMI_VERSION__: readPkgVersion('@umijs/max'),
+      __UTOO_VERSION__: readPkgVersion('@utoo/pack'),
     },
   };
 };

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -23,6 +23,8 @@ export default async (): Promise<any> => {
       ...config.globals,
       localStorage: null,
       __APP_VERSION__: 'test',
+      __UMI_VERSION__: '0.0.0',
+      __UTOO_VERSION__: '0.0.0',
     },
   };
 };

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,4 +1,7 @@
+import { createRequire } from 'node:module';
 import { configUmiAlias, createConfig } from '@umijs/max/test.js';
+
+const require = createRequire(import.meta.url);
 
 export default async (): Promise<any> => {
   const config = await configUmiAlias({
@@ -23,8 +26,8 @@ export default async (): Promise<any> => {
       ...config.globals,
       localStorage: null,
       __APP_VERSION__: 'test',
-      __UMI_VERSION__: '0.0.0',
-      __UTOO_VERSION__: '0.0.0',
+      __UMI_VERSION__: require('@umijs/max/package.json').version,
+      __UTOO_VERSION__: require('@utoo/pack/package.json').version,
     },
   };
 };

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -18,9 +18,8 @@ const getRepoUrl = () => {
 
 const REPO_URL = getRepoUrl();
 
-// Git commit hash, can be updated via CI/CD (GitHub Actions or Cloudflare Pages)
-const COMMIT_HASH =
-  process.env.COMMIT_HASH || process.env.CF_PAGES_COMMIT_SHA || '';
+// Git commit hash, resolved at build time from env vars or git
+const COMMIT_HASH = process.env.COMMIT_HASH || '';
 
 const Footer: React.FC = () => {
   return (
@@ -34,6 +33,18 @@ const Footer: React.FC = () => {
           key: 'version',
           title: `v${__APP_VERSION__}`,
           href: REPO_URL,
+          blankTarget: true,
+        },
+        {
+          key: 'umi',
+          title: `Umi ${__UMI_VERSION__}`,
+          href: 'https://umijs.org/',
+          blankTarget: true,
+        },
+        {
+          key: 'utoo',
+          title: `Utoo ${__UTOO_VERSION__}`,
+          href: 'https://utoo.land',
           blankTarget: true,
         },
         ...(COMMIT_HASH

--- a/src/pages/user/login/__snapshots__/login.test.tsx.snap
+++ b/src/pages/user/login/__snapshots__/login.test.tsx.snap
@@ -477,6 +477,24 @@ exports[`Login Page should login success 1`] = `
             </a>
             <a
               class="ant-pro-global-footer-list-link"
+              href="https://umijs.org/"
+              rel="noreferrer"
+              target="_blank"
+              title="umi"
+            >
+              Umi 4.6.47
+            </a>
+            <a
+              class="ant-pro-global-footer-list-link"
+              href="https://utoo.land"
+              rel="noreferrer"
+              target="_blank"
+              title="utoo"
+            >
+              Utoo 1.4.0
+            </a>
+            <a
+              class="ant-pro-global-footer-list-link"
               href="https://github.com/ant-design/ant-design-pro"
               rel="noreferrer"
               target="_blank"
@@ -985,6 +1003,24 @@ exports[`Login Page should show login form 1`] = `
               title="version"
             >
               vtest
+            </a>
+            <a
+              class="ant-pro-global-footer-list-link"
+              href="https://umijs.org/"
+              rel="noreferrer"
+              target="_blank"
+              title="umi"
+            >
+              Umi 4.6.47
+            </a>
+            <a
+              class="ant-pro-global-footer-list-link"
+              href="https://utoo.land"
+              rel="noreferrer"
+              target="_blank"
+              title="utoo"
+            >
+              Utoo 1.4.0
             </a>
             <a
               class="ant-pro-global-footer-list-link"

--- a/src/pages/user/login/__snapshots__/login.test.tsx.snap
+++ b/src/pages/user/login/__snapshots__/login.test.tsx.snap
@@ -482,7 +482,7 @@ exports[`Login Page should login success 1`] = `
               target="_blank"
               title="umi"
             >
-              Umi 4.6.47
+              Umi 4.6.49
             </a>
             <a
               class="ant-pro-global-footer-list-link"
@@ -491,7 +491,7 @@ exports[`Login Page should login success 1`] = `
               target="_blank"
               title="utoo"
             >
-              Utoo 1.4.0
+              Utoo 1.4.2-alpha.0
             </a>
             <a
               class="ant-pro-global-footer-list-link"
@@ -1011,7 +1011,7 @@ exports[`Login Page should show login form 1`] = `
               target="_blank"
               title="umi"
             >
-              Umi 4.6.47
+              Umi 4.6.49
             </a>
             <a
               class="ant-pro-global-footer-list-link"
@@ -1020,7 +1020,7 @@ exports[`Login Page should show login form 1`] = `
               target="_blank"
               title="utoo"
             >
-              Utoo 1.4.0
+              Utoo 1.4.2-alpha.0
             </a>
             <a
               class="ant-pro-global-footer-list-link"

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -18,3 +18,5 @@ declare module 'omit.js';
 declare module 'mockjs';
 
 declare const __APP_VERSION__: string;
+declare const __UMI_VERSION__: string;
+declare const __UTOO_VERSION__: string;


### PR DESCRIPTION
## Summary

- **Fix extra quotes in footer version**: Umi 4's `define` config auto-`JSON.stringify`s values, causing double-encoding. Removed the manual `JSON.stringify` on `__APP_VERSION__` so it displays `v6.0.0-beta.5` instead of `v"6.0.0-beta.5"`.
- **Fix missing commit hash in local builds**: Unified commit hash resolution in `config.ts` — env vars (`COMMIT_HASH`, `CF_PAGES_COMMIT_SHA`) take precedence, with `git rev-parse HEAD` as fallback so local builds also show the commit hash.
- **Add Umi and Utoo versions to footer**: Inject `__UMI_VERSION__` and `__UTOO_VERSION__` at build time, displayed as links in the footer for easier framework version debugging.
- **Add GitHub release badge to README**: Added `![GitHub release]` badge to both English and Chinese READMEs.

## Test plan

- [x] `npm run build` succeeds, build output shows `v6.0.0-beta.5` (no extra quotes)
- [x] Build output correctly injects `Umi 4.6.47` and `Utoo 1.4.0`
- [x] Local build correctly resolves commit hash via `git rev-parse HEAD`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 在 README（含中文版）顶部添加 GitHub Releases 版本徽标，便于访问最新发布
  * 页脚新增 Umi 与 Utoo 版本链接显示

* **改进**
  * 构建与测试配置现在统一提供额外的版本信息，改进版本展示与管理
  * 当提交哈希不可用时，页面将不再显示提交链接

* **文档**
  * 新增项目使用与维护说明文档（CLAUDE.md）
<!-- end of auto-generated comment: release notes by coderabbit.ai -->