### PR TITLE
fix: resolve 404 page blank screen

### DIFF
--- a/config/routes.ts
+++ b/config/routes.ts
@@ -37,7 +37,7 @@ export default [
         component: './user/register',
       },
       {
-        component: '404',
+        component: './404',
         path: '/user/*',
       },
     ],
@@ -290,7 +290,7 @@ export default [
     redirect: '/dashboard/analysis',
   },
   {
-    component: '404',
+    component: './404',
     path: './*',
   },
 ];


### PR DESCRIPTION
## Summary

- Fix 404 page rendering blank screen when visiting non-existent routes (e.g., `/xxx`)
- Change `component: '404'` to `component: './404'` in `config/routes.ts` so Umi correctly resolves to `src/pages/404.tsx`
- Affects both the root-level catch-all route (`./*`) and the `/user/*` sub-route

## Root Cause

Umi resolves `component` values starting with `./` relative to `src/pages/`. Without the `./` prefix, `'404'` is treated as a non-resolvable module path, resulting in no component being rendered (blank white screen).

## Test plan

- [ ] Visit `http://127.0.0.1:8000/xxx` — should render 404 page with Result component
- [ ] Visit `http://127.0.0.1:8000/user/nonexistent` — should render 404 page
- [ ] Verify existing routes still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **优化**
  * 改进了路由配置的内部引用方式，增强了代码的可维护性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->