### PR TITLE
fix: correct global 404 catch-all route path

### DIFF
--- a/config/routes.ts
+++ b/config/routes.ts
@@ -37,6 +37,7 @@ export default [
         component: './user/register',
       },
       {
+        name: '404',
         component: './404',
         path: '/user/*',
       },
@@ -290,7 +291,8 @@ export default [
     redirect: '/dashboard/analysis',
   },
   {
+    name: '404',
     component: './404',
-    path: './*',
+    path: '/*',
   },
 ];


### PR DESCRIPTION
## Summary

- Fix the global 404 catch-all route path from `./*` to `/*`, which was the actual root cause of blank screens on unknown routes (e.g. `/xxx`). The previous fix (#11729) only corrected the component reference format but missed that `./*` is a non-standard path in Umi/React Router that matches no real URL.
- Add `name: '404'` to both 404 route entries for i18n mapping consistency.

## Test plan

- [ ] Visit `/xxx` (unknown route) — should render the 404 page instead of a blank screen
- [ ] Visit `/user/nonexistent` — should render the 404 page within the user layout
- [ ] Verify all existing routes still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 优化了404错误页面路由配置，改进了应用对未找到页面的处理方式。
  * 更新了路由匹配规则，确保错误页面在各路径层级下正确显示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->