### PR TITLE
feat: add gradient celebration title to Welcome page

### DIFF
--- a/src/locales/bn-BD/pages.ts
+++ b/src/locales/bn-BD/pages.ts
@@ -25,6 +25,7 @@ export default {
   'pages.login.loginWith': 'লগইন করতে পারেন:',
   'pages.login.registerAccount': 'অ্যাকাউন্ট নিবন্ধন করুন',
   'pages.welcome.link': 'স্বাগতম',
+  'pages.welcome.celebrationTitle': 'Ant Design Pro V6 এ স্বাগতম 🎉',
   'pages.welcome.alertMessage': 'দ্রুত এবং শক্তিশালী ভারী শুল্ক উপাদান প্রকাশ করা হয়েছে।',
   'pages.404.subTitle': 'দুঃখিত, আপনি যে পৃষ্ঠাটি দেখতে চান তা বিদ্যমান নেই।',
   'pages.404.buttonText': 'প্রধান পাতায় ফিরে যান',

--- a/src/locales/bn-BD/pages.ts
+++ b/src/locales/bn-BD/pages.ts
@@ -25,7 +25,7 @@ export default {
   'pages.login.loginWith': 'লগইন করতে পারেন:',
   'pages.login.registerAccount': 'অ্যাকাউন্ট নিবন্ধন করুন',
   'pages.welcome.link': 'স্বাগতম',
-  'pages.welcome.celebrationTitle': 'Ant Design Pro V6 এ স্বাগতম 🎉',
+  'pages.welcome.celebrationTitle': 'Ant Design Pro {v6} এ স্বাগতম',
   'pages.welcome.alertMessage': 'দ্রুত এবং শক্তিশালী ভারী শুল্ক উপাদান প্রকাশ করা হয়েছে।',
   'pages.404.subTitle': 'দুঃখিত, আপনি যে পৃষ্ঠাটি দেখতে চান তা বিদ্যমান নেই।',
   'pages.404.buttonText': 'প্রধান পাতায় ফিরে যান',

--- a/src/locales/en-US/pages.ts
+++ b/src/locales/en-US/pages.ts
@@ -25,7 +25,7 @@ export default {
   'pages.login.loginWith': 'Login with :',
   'pages.login.registerAccount': 'Register Account',
   'pages.welcome.link': 'Welcome',
-  'pages.welcome.celebrationTitle': 'Welcome to Ant Design Pro V6 🎉',
+  'pages.welcome.celebrationTitle': 'Welcome to Ant Design Pro {v6}',
   'pages.welcome.alertMessage':
     'Faster and stronger heavy-duty components have been released.',
   'pages.welcome.infoCard.umi.title': 'Learn umi',

--- a/src/locales/en-US/pages.ts
+++ b/src/locales/en-US/pages.ts
@@ -25,6 +25,7 @@ export default {
   'pages.login.loginWith': 'Login with :',
   'pages.login.registerAccount': 'Register Account',
   'pages.welcome.link': 'Welcome',
+  'pages.welcome.celebrationTitle': 'Welcome to Ant Design Pro V6 🎉',
   'pages.welcome.alertMessage':
     'Faster and stronger heavy-duty components have been released.',
   'pages.welcome.infoCard.umi.title': 'Learn umi',

--- a/src/locales/fa-IR/pages.ts
+++ b/src/locales/fa-IR/pages.ts
@@ -26,6 +26,7 @@ export default {
   'pages.login.loginWith': 'وارد شوید با :',
   'pages.login.registerAccount': 'ثبت نام',
   'pages.welcome.link': 'خوش آمدید',
+  'pages.welcome.celebrationTitle': 'به Ant Design Pro V6 خوش آمدید 🎉',
   'pages.welcome.alertMessage': 'اجزای سنگین تر سریعتر و قوی تر آزاد شده اند.',
   'pages.404.subTitle': 'ببخشيد، صفحه اي که ديديد وجود نداره',
   'pages.404.buttonText': 'بازگشت به صفحه اصلی',

--- a/src/locales/fa-IR/pages.ts
+++ b/src/locales/fa-IR/pages.ts
@@ -26,7 +26,7 @@ export default {
   'pages.login.loginWith': 'وارد شوید با :',
   'pages.login.registerAccount': 'ثبت نام',
   'pages.welcome.link': 'خوش آمدید',
-  'pages.welcome.celebrationTitle': 'به Ant Design Pro V6 خوش آمدید 🎉',
+  'pages.welcome.celebrationTitle': 'به Ant Design Pro {v6} خوش آمدید',
   'pages.welcome.alertMessage': 'اجزای سنگین تر سریعتر و قوی تر آزاد شده اند.',
   'pages.404.subTitle': 'ببخشيد، صفحه اي که ديديد وجود نداره',
   'pages.404.buttonText': 'بازگشت به صفحه اصلی',

--- a/src/locales/id-ID/pages.ts
+++ b/src/locales/id-ID/pages.ts
@@ -25,7 +25,7 @@ export default {
   'pages.login.loginWith': 'Masuk dengan :',
   'pages.login.registerAccount': 'Daftar Akun',
   'pages.welcome.link': 'Selamat datang',
-  'pages.welcome.celebrationTitle': 'Selamat datang di Ant Design Pro V6 🎉',
+  'pages.welcome.celebrationTitle': 'Selamat datang di Ant Design Pro {v6}',
   'pages.welcome.alertMessage':
     'Komponen heavy-duty yang lebih cepat dan lebih kuat telah dirilis.',
   'pages.404.subTitle': 'Maaf, halaman yang Anda kunjungi tidak ada. ',

--- a/src/locales/id-ID/pages.ts
+++ b/src/locales/id-ID/pages.ts
@@ -25,6 +25,7 @@ export default {
   'pages.login.loginWith': 'Masuk dengan :',
   'pages.login.registerAccount': 'Daftar Akun',
   'pages.welcome.link': 'Selamat datang',
+  'pages.welcome.celebrationTitle': 'Selamat datang di Ant Design Pro V6 🎉',
   'pages.welcome.alertMessage':
     'Komponen heavy-duty yang lebih cepat dan lebih kuat telah dirilis.',
   'pages.404.subTitle': 'Maaf, halaman yang Anda kunjungi tidak ada. ',

--- a/src/locales/ja-JP/pages.ts
+++ b/src/locales/ja-JP/pages.ts
@@ -25,6 +25,7 @@ export default {
   'pages.login.loginWith': 'その他のログイン方法：',
   'pages.login.registerAccount': 'アカウント登録',
   'pages.welcome.link': 'ようこそ',
+  'pages.welcome.celebrationTitle': 'Ant Design Pro V6 へようこそ 🎉',
   'pages.welcome.alertMessage':
     'より高速で強力な頑丈なコンポーネントがリリースされました。',
   'pages.404.subTitle':

--- a/src/locales/ja-JP/pages.ts
+++ b/src/locales/ja-JP/pages.ts
@@ -25,7 +25,7 @@ export default {
   'pages.login.loginWith': 'その他のログイン方法：',
   'pages.login.registerAccount': 'アカウント登録',
   'pages.welcome.link': 'ようこそ',
-  'pages.welcome.celebrationTitle': 'Ant Design Pro V6 へようこそ 🎉',
+  'pages.welcome.celebrationTitle': 'Ant Design Pro {v6} へようこそ',
   'pages.welcome.alertMessage':
     'より高速で強力な頑丈なコンポーネントがリリースされました。',
   'pages.404.subTitle':

--- a/src/locales/pt-BR/pages.ts
+++ b/src/locales/pt-BR/pages.ts
@@ -26,6 +26,7 @@ export default {
   'pages.login.loginWith': 'Login com :',
   'pages.login.registerAccount': 'Registra Conta',
   'pages.welcome.link': 'Bem-vindo',
+  'pages.welcome.celebrationTitle': 'Bem-vindo ao Ant Design Pro V6 🎉',
   'pages.welcome.alertMessage':
     'Componentes pesados mais rápidos e mais fortes foram lançados.',
   'pages.404.subTitle': 'Desculpe, a página que você visitou não existe. ',

--- a/src/locales/pt-BR/pages.ts
+++ b/src/locales/pt-BR/pages.ts
@@ -26,7 +26,7 @@ export default {
   'pages.login.loginWith': 'Login com :',
   'pages.login.registerAccount': 'Registra Conta',
   'pages.welcome.link': 'Bem-vindo',
-  'pages.welcome.celebrationTitle': 'Bem-vindo ao Ant Design Pro V6 🎉',
+  'pages.welcome.celebrationTitle': 'Bem-vindo ao Ant Design Pro {v6}',
   'pages.welcome.alertMessage':
     'Componentes pesados mais rápidos e mais fortes foram lançados.',
   'pages.404.subTitle': 'Desculpe, a página que você visitou não existe. ',

--- a/src/locales/zh-CN/pages.ts
+++ b/src/locales/zh-CN/pages.ts
@@ -25,7 +25,7 @@ export default {
   'pages.login.loginWith': '其他登录方式 :',
   'pages.login.registerAccount': '注册账户',
   'pages.welcome.link': '欢迎使用',
-  'pages.welcome.celebrationTitle': '欢迎使用 Ant Design Pro V6 🎉',
+  'pages.welcome.celebrationTitle': '欢迎使用 Ant Design Pro {v6}',
   'pages.welcome.alertMessage': '更快更强的重型组件，已经发布。',
   'pages.welcome.infoCard.umi.title': '了解 umi',
   'pages.welcome.infoCard.umi.desc':

--- a/src/locales/zh-CN/pages.ts
+++ b/src/locales/zh-CN/pages.ts
@@ -25,6 +25,7 @@ export default {
   'pages.login.loginWith': '其他登录方式 :',
   'pages.login.registerAccount': '注册账户',
   'pages.welcome.link': '欢迎使用',
+  'pages.welcome.celebrationTitle': '欢迎使用 Ant Design Pro V6 🎉',
   'pages.welcome.alertMessage': '更快更强的重型组件，已经发布。',
   'pages.welcome.infoCard.umi.title': '了解 umi',
   'pages.welcome.infoCard.umi.desc':

--- a/src/locales/zh-TW/pages.ts
+++ b/src/locales/zh-TW/pages.ts
@@ -25,7 +25,7 @@ export default {
   'pages.login.loginWith': '其他登錄方式 :',
   'pages.login.registerAccount': '註冊賬戶',
   'pages.welcome.link': '歡迎使用',
-  'pages.welcome.celebrationTitle': '歡迎使用 Ant Design Pro V6 🎉',
+  'pages.welcome.celebrationTitle': '歡迎使用 Ant Design Pro {v6}',
   'pages.welcome.alertMessage': '更快更強的重型組件，已經發布。',
   'pages.404.subTitle': '抱歉，您訪問的頁面不存在。',
   'pages.404.buttonText': '返回首頁',

--- a/src/locales/zh-TW/pages.ts
+++ b/src/locales/zh-TW/pages.ts
@@ -25,6 +25,7 @@ export default {
   'pages.login.loginWith': '其他登錄方式 :',
   'pages.login.registerAccount': '註冊賬戶',
   'pages.welcome.link': '歡迎使用',
+  'pages.welcome.celebrationTitle': '歡迎使用 Ant Design Pro V6 🎉',
   'pages.welcome.alertMessage': '更快更強的重型組件，已經發布。',
   'pages.404.subTitle': '抱歉，您訪問的頁面不存在。',
   'pages.404.buttonText': '返回首頁',

--- a/src/pages/Welcome.css
+++ b/src/pages/Welcome.css
@@ -1,3 +1,10 @@
+.welcome-gradient-title {
+  background: linear-gradient(135deg, #1677ff 0%, #722ed1 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
 .welcome-markdown .x-markdown {
   --md-heading-weight: 600;
   --md-code-bg: rgba(0, 0, 0, 0.04);

--- a/src/pages/Welcome.tsx
+++ b/src/pages/Welcome.tsx
@@ -154,12 +154,22 @@ const Welcome: React.FC = () => {
   return (
     <PageContainer
       title={
-        <span className="welcome-gradient-title">
-          {intl.formatMessage({
-            id: 'pages.welcome.celebrationTitle',
-            defaultMessage: '欢迎使用 Ant Design Pro V6 🎉',
-          })}
-        </span>
+        <>
+          {intl.formatMessage(
+            {
+              id: 'pages.welcome.celebrationTitle',
+              defaultMessage: '欢迎使用 Ant Design Pro {v6}',
+            },
+            {
+              v6: (
+                <span key="v6" className="welcome-gradient-title">
+                  V6
+                </span>
+              ),
+            },
+          )}
+          🎉
+        </>
       }
     >
       <div

--- a/src/pages/Welcome.tsx
+++ b/src/pages/Welcome.tsx
@@ -152,7 +152,16 @@ const Welcome: React.FC = () => {
   const isDark = initialState?.settings?.navTheme === 'realDark';
 
   return (
-    <PageContainer>
+    <PageContainer
+      title={
+        <span className="welcome-gradient-title">
+          {intl.formatMessage({
+            id: 'pages.welcome.celebrationTitle',
+            defaultMessage: '欢迎使用 Ant Design Pro V6 🎉',
+          })}
+        </span>
+      }
+    >
       <div
         data-theme={isDark ? 'dark' : 'light'}
         className="flex flex-col gap-6 md:flex-row"


### PR DESCRIPTION
## Summary

- Welcome 页面标题改为「欢迎使用 Ant Design Pro V6 🎉」，应用蓝紫渐变色（`#1677ff` → `#722ed1`）
- 新增 i18n key `pages.welcome.celebrationTitle`，覆盖全部 8 种语言
- 左侧菜单标题保持「欢迎」不变（由 `menu.welcome` 控制，未修改）

## Test plan

- [ ] 验证 Welcome 页面标题显示渐变色文字
- [ ] 验证左侧菜单仍显示「欢迎」
- [ ] 切换语言验证各 locale 的 celebrationTitle 正确显示
- [ ] 验证暗色模式下渐变色正常渲染

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 发布说明

* **新功能**
  * Welcome 页面新增庆祝性标题（含 V6 标识与 🎉 表情），并应用渐变文字样式以提升视觉效果。
  * 为多个语言新增或补充该欢迎标题的本地化翻译（包括中文、英文、日文、波斯文、葡萄牙文、印尼文、孟加拉语等），改善多语言体验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->