### PR TITLE
fix: remove 404 from sidebar menu

### DIFF
--- a/config/routes.ts
+++ b/config/routes.ts
@@ -291,7 +291,6 @@ export default [
     redirect: '/dashboard/analysis',
   },
   {
-    name: '404',
     component: './exception/404',
     path: '/*',
   },


### PR DESCRIPTION
## Summary
- Remove `name` property from the global 404 catch-all route (`/*`) to prevent it from appearing as a standalone menu item in the sidebar
- 404 page is already available under the exception group (`/exception/404`), the duplicate menu entry was unnecessary

## Test plan
- [ ] Verify sidebar no longer shows a standalone 404 menu item
- [ ] Verify 404 still appears under the exception menu group
- [ ] Verify navigating to a non-existent path still renders the 404 page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **杂项**
  * 优化了路由配置，提升代码整洁度。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->