### PR TITLE
docs: update links

### DIFF
--- a/docs/cheatsheet.en-US.md
+++ b/docs/cheatsheet.en-US.md
@@ -176,7 +176,7 @@ const Page = () => (
 
 → See [Umi Max Layout & Menu](https://umijs.org/en-US/docs/max/layout-menu)
 
-## Data Stream
+## Data Flow
 
 **useModel — lightweight global state:** Create a file in `src/models/` to auto-register:
 

--- a/docs/cheatsheet.en-US.md
+++ b/docs/cheatsheet.en-US.md
@@ -242,7 +242,7 @@ const { initialState } = useModel('@@initialState');
 
 > 💡 `getInitialState` runs once on app startup, ideal for fetching global info (user identity, permissions).
 
-→ See [Umi Max Data Stream](https://umijs.org/en-US/docs/max/data-flow)
+→ See [Umi Max Data Flow](https://umijs.org/en-US/docs/max/data-flow)
 
 ## Request
 

--- a/docs/cheatsheet.en-US.md
+++ b/docs/cheatsheet.en-US.md
@@ -93,7 +93,7 @@ npm install                                                # Update dependencies
 
 **Build tool:** This project uses [utoopack](https://github.com/utooland/utoo) (a next-gen bundler powered by Turbopack) as the default build tool, configured via the `utoopack` field in `config/config.ts`. utoopack is Webpack-compatible and supports `module.rules` for custom loaders.
 
-→ See [umi Getting Started](https://umijs.org/docs/guides/getting-started), [utoo Docs](https://utoo.land)
+→ See [umi Getting Started](https://umijs.org/en-US/docs/guides/getting-started), [utoo Docs](https://utoo.land)
 
 ## Routes & Menu
 
@@ -136,7 +136,7 @@ const location = useLocation(); // current route info
 
 > 💡 The `name` field is automatically mapped to `menu.xxx` i18n keys. Configure translations in `src/locales/`.
 
-→ See [umi Routes](https://umijs.org/docs/guides/routes), [Umi Max Layout & Menu](https://umijs.org/docs/max/layout-menu)
+→ See [umi Routes](https://umijs.org/en-US/docs/guides/routes), [Umi Max Layout & Menu](https://umijs.org/en-US/docs/max/layout-menu)
 
 ## Layout
 
@@ -174,9 +174,9 @@ const Page = () => (
 
 **Custom areas:** Top-right `src/components/RightContent`, footer `src/components/Footer`.
 
-→ See [Umi Max Layout & Menu](https://umijs.org/docs/max/layout-menu)
+→ See [Umi Max Layout & Menu](https://umijs.org/en-US/docs/max/layout-menu)
 
-## Data Flow
+## Data Stream
 
 **useModel — lightweight global state:** Create a file in `src/models/` to auto-register:
 
@@ -242,7 +242,7 @@ const { initialState } = useModel('@@initialState');
 
 > 💡 `getInitialState` runs once on app startup, ideal for fetching global info (user identity, permissions).
 
-→ See [Umi Max Data Flow](https://umijs.org/docs/max/data-flow)
+→ See [Umi Max Data Stream](https://umijs.org/en-US/docs/max/data-flow)
 
 ## Request
 
@@ -281,9 +281,9 @@ Auto-generates API calling code under `src/services/` based on `config/oneapi.js
 
 > 💡 Generated code uses `import { request } from '@umijs/max'` directly — no manual wrapping needed.
 
-→ See [Umi Max Request](https://umijs.org/docs/max/request)
+→ See [Umi Max Request](https://umijs.org/en-US/docs/max/request)
 
-## Access Control
+## Permissions
 
 **Define permissions** in `src/access.ts`:
 
@@ -318,7 +318,7 @@ const access = useAccess();
 if (access.canAdmin) { /* ... */ }
 ```
 
-→ See [Umi Max Access](https://umijs.org/docs/max/access)
+→ See [Umi Max Permissions](https://umijs.org/en-US/docs/max/access)
 
 ## Internationalization
 
@@ -366,7 +366,7 @@ import { setLocale } from '@umijs/max';
 setLocale('en-US', false);  // false = no page reload
 ```
 
-→ See [Umi Max i18n](https://umijs.org/docs/max/i18n)
+→ See [Umi Max i18n](https://umijs.org/en-US/docs/max/i18n)
 
 ## Styling
 
@@ -424,7 +424,7 @@ Use SettingDrawer in dev mode to switch themes in real-time.
 
 > 💡 Three styling approaches can coexist: Tailwind for layout, CSS Modules for component styles, antd-style when consuming theme tokens.
 
-→ See [umi Styling](https://umijs.org/docs/guides/styling), [Umi Max antd Dynamic Theme](https://umijs.org/docs/max/antd#动态主题)
+→ See [umi Styling](https://umijs.org/en-US/docs/guides/styling), [Umi Max antd Dynamic Theme](https://umijs.org/en-US/docs/max/antd#dynamically-switch-global-configuration)
 
 ## Testing & Debugging
 
@@ -465,7 +465,7 @@ export default {
 
 > 💡 Use `MOCK=none` to skip mock and proxy to backend: `npm run start:no-mock`.
 
-→ See [umi Testing](https://umijs.org/docs/guides/testing), [umi Mock](https://umijs.org/docs/guides/mock)
+→ See [umi Testing](https://umijs.org/en-US/docs/guides/test), [umi Mock](https://umijs.org/en-US/docs/guides/mock)
 
 ## FAQ
 
@@ -487,4 +487,4 @@ Create a file in `src/models/` exporting a custom Hook, then use `useModel('file
 **Q: How to use OpenAPI code generation?**
 1. Configure `openAPI` in `config/config.ts` 2. Run `npm run openapi` 3. Code is auto-generated under `src/services/`
 
-→ See [umi FAQ](https://umijs.org/docs/guides/faq)
+→ See [umi FAQ](https://umijs.org/en-US/docs/introduce/faq)

--- a/docs/cheatsheet.zh-CN.md
+++ b/docs/cheatsheet.zh-CN.md
@@ -424,7 +424,7 @@ antd: {
 
 > 💡 三种样式方案可以共存：Tailwind 适合布局、CSS Modules 适合组件样式、antd-style 适合需要消费主题 token 的场景。
 
-→ 更多内容见 [umi 样式文档](https://umijs.org/docs/guides/styling)、[Umi Max antd 动态主题](https://umijs.org/docs/max/antd#动态主题)
+→ 更多内容见 [umi 样式文档](https://umijs.org/docs/guides/styling)、[Umi Max antd 动态主题](https://umijs.org/docs/max/antd#动态切换全局配置)
 
 ## 测试 & 调试
 
@@ -465,7 +465,7 @@ export default {
 
 > 💡 用 `MOCK=none` 启动可跳过 Mock，直接代理到后端：`npm run start:no-mock`。
 
-→ 更多内容见 [umi 测试](https://umijs.org/docs/guides/testing)、[umi Mock](https://umijs.org/docs/guides/mock)
+→ 更多内容见 [umi 测试](https://umijs.org/docs/guides/test)、[umi Mock](https://umijs.org/docs/guides/mock)
 
 ## FAQ
 
@@ -487,4 +487,4 @@ export default {
 **Q: 如何使用 OpenAPI 代码生成？**
 1. 在 `config/config.ts` 配置 `openAPI` 2. 运行 `npm run openapi` 3. 自动生成 `src/services/` 下的代码
 
-→ 更多内容见 [umi FAQ](https://umijs.org/docs/guides/faq)
+→ 更多内容见 [umi FAQ](https://umijs.org/docs/introduce/faq)


### PR DESCRIPTION
文档部分链接指向了错误的链接.
英文链接加上了 /en-US


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **文档更新**
  * 更新快速参考指南中的外部文档链接，修正并重定向至最新版 Umi/Max 文档路由（含 en-US 路径调整与若干指南路由更改）
  * 将“Access Control”标题改为“Permissions”并更新对应引用文本
  * 修复文档末尾缺失换行，优化导航与可读性
<!-- end of auto-generated comment: release notes by coderabbit.ai -->