### PR TITLE
fix: resolve Windows "Can't resolve tailwindcss" error

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,35 @@
-module.exports = {
-  plugins: {
-    '@tailwindcss/postcss': {},
+const path = require('path');
+const fs = require('fs');
+
+/**
+ * Workaround for turbopack Windows path doubling bug.
+ * On Windows, turbopack may pass a doubled relative path as the `from` option
+ * to PostCSS (e.g. `./Desktop/demo/project/src/file.css` instead of `./src/file.css`),
+ * causing `path.resolve(cwd, from)` to produce a non-existent doubled path.
+ * This plugin detects and corrects the path before @tailwindcss/postcss reads it.
+ * @see https://github.com/ant-design/ant-design-pro/issues/11747
+ */
+const fixWindowsPathPlugin = {
+  postcssPlugin: 'fix-turbopack-windows-path',
+  Once(_root, { result }) {
+    const from = result.opts.from;
+    if (!from || fs.existsSync(from)) return;
+
+    const cwd = process.cwd();
+    const resolved = path.resolve(from);
+    const relative = path.relative(cwd, resolved);
+    const parts = relative.split(path.sep);
+
+    for (let i = 1; i < parts.length; i++) {
+      const candidate = path.join(cwd, ...parts.slice(i));
+      if (fs.existsSync(candidate)) {
+        result.opts.from = candidate;
+        return;
+      }
+    }
   },
+};
+
+module.exports = {
+  plugins: [fixWindowsPathPlugin, require('@tailwindcss/postcss')],
 };

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,35 +1,5 @@
-const path = require('path');
-const fs = require('fs');
-
-/**
- * Workaround for turbopack Windows path doubling bug.
- * On Windows, turbopack may pass a doubled relative path as the `from` option
- * to PostCSS (e.g. `./Desktop/demo/project/src/file.css` instead of `./src/file.css`),
- * causing `path.resolve(cwd, from)` to produce a non-existent doubled path.
- * This plugin detects and corrects the path before @tailwindcss/postcss reads it.
- * @see https://github.com/ant-design/ant-design-pro/issues/11747
- */
-const fixWindowsPathPlugin = {
-  postcssPlugin: 'fix-turbopack-windows-path',
-  Once(_root, { result }) {
-    const from = result.opts.from;
-    if (!from || fs.existsSync(from)) return;
-
-    const cwd = process.cwd();
-    const resolved = path.resolve(from);
-    const relative = path.relative(cwd, resolved);
-    const parts = relative.split(path.sep);
-
-    for (let i = 1; i < parts.length; i++) {
-      const candidate = path.join(cwd, ...parts.slice(i));
-      if (fs.existsSync(candidate)) {
-        result.opts.from = candidate;
-        return;
-      }
-    }
-  },
-};
-
 module.exports = {
-  plugins: [fixWindowsPathPlugin, require('@tailwindcss/postcss')],
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
 };

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -1,3 +1,3 @@
 @import "tailwindcss";
 
-@source "./src";
+@source ".";


### PR DESCRIPTION
## Summary

- 修复 `src/tailwind.css` 中 `@source "./src"` → `@source "."`
- `@source` 路径相对于 CSS 文件本身解析，`./src` 从 `src/tailwind.css` 出发会解析到不存在的 `src/src/` 目录，改为 `.` 正确指向 `src/` 目录

## 关于 #11747

此 PR 修复了一个确认的 `@source` 配置错误。但 #11747 报告的 Windows `Can't resolve 'tailwindcss'` 错误的根因仍需进一步排查：

- 本项目 CI 在 `windows-latest` 上运行 `ut build` 是通过的，说明 turbopack Windows 路径处理不存在通用性问题
- 可能的触发条件：dev 模式 (`max dev`) vs build 模式、Node.js v24、`Desktop` 特殊目录（OneDrive 重定向/junction）
- 需要 issue 报告者提供更多信息来复现

## Test plan

- [x] macOS `npm start` 正常
- [x] `tsc --noEmit` 通过
- [x] lint-staged / biome 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)