### PR TITLE
fix: 修复执行simple后404页面丢失无法启动问题

### DIFF
--- a/config/routes.simple.ts
+++ b/config/routes.simple.ts
@@ -48,7 +48,7 @@ export default [
     redirect: '/welcome',
   },
   {
-    component: '404',
+    component: './exception/404',
     layout: false,
     path: './*',
   },

--- a/scripts/simple.js
+++ b/scripts/simple.js
@@ -20,7 +20,6 @@ const pageDirsToDelete = [
   'src/pages/list/search',
   'src/pages/profile',
   'src/pages/result',
-  'src/pages/exception',
   'src/pages/account',
   'src/pages/user/register',
   'src/pages/user/register-result',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **Chores（维护）**
  * 更新了错误页面的路由加载配置。
  * 调整了页面清理脚本，使特定目录在运行时不再被删除。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->