### PR TITLE
fix: resolve intermittent "Can't resolve 'tailwindcss'" on Windows

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,3 +1,35 @@
+const path = require('path');
+
+// Workaround for https://github.com/ant-design/ant-design-pro/issues/11747
+// On Windows, @tailwindcss/node uses enhanced-resolve with a 4-second
+// CachedInputFileSystem that can cache stale negative results (e.g. when
+// Windows Defender locks node_modules). This causes intermittent
+// "Can't resolve 'tailwindcss'" errors. Setting __tw_resolve bypasses
+// enhanced-resolve by using Node.js require.resolve, which is reliable.
+if (typeof globalThis.__tw_resolve !== 'function') {
+  globalThis.__tw_resolve = (specifier, fromDir) => {
+    if (specifier.startsWith('.') || specifier.startsWith('/')) return;
+    try {
+      const pkgJsonPath = require.resolve(specifier + '/package.json', {
+        paths: [fromDir],
+      });
+      const pkg = require(pkgJsonPath);
+      const pkgDir = path.dirname(pkgJsonPath);
+      if (pkg.exports?.['.']?.style) {
+        return path.join(pkgDir, pkg.exports['.'].style);
+      }
+      if (pkg.style) {
+        return path.join(pkgDir, pkg.style);
+      }
+      const indexPath = path.join(pkgDir, 'index.css');
+      try {
+        require('fs').accessSync(indexPath);
+        return indexPath;
+      } catch {}
+    } catch {}
+  };
+}
+
 module.exports = {
   plugins: {
     '@tailwindcss/postcss': {},

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -1,3 +1,3 @@
 @import "tailwindcss";
 
-@source "./src";
+@source ".";


### PR DESCRIPTION
## Summary

Fixes #11747

Two changes to fix the intermittent `Can't resolve 'tailwindcss'` error on Windows:

1. **`postcss.config.js`**: Set `globalThis.__tw_resolve` to bypass `enhanced-resolve`'s `CachedInputFileSystem` (4-second cache) which caches stale negative results on Windows — typically when Windows Defender scans `node_modules`, causing intermittent resolution failures. The custom resolver uses Node.js's `require.resolve` instead, which is reliable on all platforms.

2. **`src/tailwind.css`**: Fix `@source "./src"` → `@source "."` — the `@source` directive resolves paths relative to the CSS file, so `./src` from `src/tailwind.css` points to the non-existent `src/src/` directory.

### Root Cause

`@tailwindcss/node` uses `enhanced-resolve` with `CachedInputFileSystem(fs, 4000)` to resolve `@import "tailwindcss"`. On Windows:
- The 4-second file system cache can cache a failed `stat` result (e.g., when Windows Defender temporarily locks `node_modules`)
- All resolution attempts within the cache window fail with the same stale negative result
- This explains the intermittent behavior: sometimes the first `stat` succeeds, sometimes it doesn't

The `globalThis.__tw_resolve` hook is [checked first](https://github.com/tailwindlabs/tailwindcss/blob/main/packages/@tailwindcss-node/src/resolve.ts) by `@tailwindcss/node` before falling back to `enhanced-resolve`, making it the intended escape hatch for this exact scenario.

## Test plan

- [x] `npm start` starts successfully on macOS
- [ ] Verify on Windows that `npm start` no longer intermittently fails with `Can't resolve 'tailwindcss'`
- [ ] Verify `npm run build` works on Windows
- [ ] Verify Tailwind CSS utility classes still apply correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **修复**
  * 修复了Windows系统上偶发的Tailwind CSS解析错误，通过添加系统级解决方案确保稳定构建。

* **配置优化**
  * 更新了样式源配置路径，改进项目构建流程。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->