### PR TITLE
fix: replace deprecated Divider `type` prop with `orientation`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ Each page directory contains its own index.tsx, optional service.ts, _mock.ts, d
 - `npx antd demo <Component> <name>` — get working demo code
 - `npx antd token <Component>` — check design tokens
 - `npx antd semantic <Component>` — check semantic classNames
-- `npx antd lint ./src` — find deprecated or problematic antd usage
+- `npx antd lint ./src` — find deprecated or problematic antd usage. **Must pass with zero errors and warnings before committing**
 - `npx antd doctor` — diagnose project configuration issues
 - `npx antd migrate <v1> <v2>` — migration checklist between versions
 - Always use `--format json` for structured output

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -92,7 +92,7 @@ const Footer: React.FC = () => {
             </a>
           )}
         </span>
-        <Divider type="vertical" className={styles.divider} />
+        <Divider orientation="vertical" className={styles.divider} />
         <span className={styles.group}>
           <span className={styles.label}>Umi</span>
           <a
@@ -104,7 +104,7 @@ const Footer: React.FC = () => {
             {__UMI_VERSION__}
           </a>
         </span>
-        <Divider type="vertical" className={styles.divider} />
+        <Divider orientation="vertical" className={styles.divider} />
         <span className={styles.group}>
           <span className={styles.label}>Utoo</span>
           <a
@@ -116,7 +116,7 @@ const Footer: React.FC = () => {
             {__UTOO_VERSION__}
           </a>
         </span>
-        <Divider type="vertical" className={styles.divider} />
+        <Divider orientation="vertical" className={styles.divider} />
         <a
           className={styles.link}
           href={REPO_URL}


### PR DESCRIPTION
## Summary

- Replace deprecated `Divider type="vertical"` with `Divider orientation="vertical"` in `src/components/Footer/index.tsx` (antd v6 deprecation)
- Document in CLAUDE.md that `npx antd lint ./src` must pass with zero errors and warnings before committing

## Test plan

- [x] `npx antd lint ./src` passes with zero issues
- [ ] Verify no `[antd: Divider] type is deprecated` console warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 页脚新增Utoo版本显示模块。

* **文档**
  * 更新CLI lint命令文档，补充零错误零警告的要求说明。

* **改进**
  * 更新分隔线组件用法，采用新的API参数方式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->