### PR TITLE
fix: enable valtio plugin to fix proxy undefined error

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,7 @@ Umi Max (`@umijs/max`) is the meta-framework. It wraps the build pipeline and pr
 - **`useModel('@@initialState')`** for global state (currentUser, settings). Initialized by `getInitialState()` in `app.tsx` which runs once on app startup
 - **`useRequest`** from `@umijs/max` for simple data fetching
 - **@tanstack/react-query** for complex server state (e.g., table-list uses `useMutation` + `useQuery`)
+- **Valtio** (`proxy`, `useSnapshot`): proxy-based reactive state for fine-grained updates. Import from `@umijs/max`. Create stores with `proxy()` at module level, read with `useSnapshot()` in components
 - Most pages use ProTable's built-in `request` prop for data loading
 
 ### Styling Systems

--- a/config/config.ts
+++ b/config/config.ts
@@ -174,6 +174,12 @@ export default defineConfig({
    */
   access: {},
   /**
+   * @name Valtio 插件
+   * @description 基于 valtio 的状态管理方案
+   * @doc https://umijs.org/docs/max/valtio
+   */
+  valtio: {},
+  /**
    * @name Google Analytics
    * @description 使用 GA4 (gtag.js) 进行站点分析
    * @doc https://umijs.org/docs/max/analytics

--- a/docs/cheatsheet.en-US.md
+++ b/docs/cheatsheet.en-US.md
@@ -234,6 +234,26 @@ const mutation = useMutation({
 });
 ```
 
+**Valtio — reactive state management:** Proxy-based reactive state for fine-grained updates:
+
+```ts
+// Create store (can be at module level in any file)
+import { proxy, useSnapshot } from '@umijs/max';
+
+export const settingsStore = proxy({
+  theme: 'light' as 'light' | 'dark',
+  sidebarCollapsed: false,
+});
+
+// Use in components
+function ThemeToggle() {
+  const snap = useSnapshot(settingsStore);
+  return <button onClick={() => { settingsStore.theme = snap.theme === 'light' ? 'dark' : 'light'; }}>
+    Current theme: {snap.theme}
+  </button>;
+}
+```
+
 **Initial state — getInitialState:** Define in `src/app.tsx`, accessible globally:
 
 ```tsx

--- a/docs/cheatsheet.zh-CN.md
+++ b/docs/cheatsheet.zh-CN.md
@@ -234,6 +234,26 @@ const mutation = useMutation({
 });
 ```
 
+**Valtio — 响应式状态管理：** 基于 proxy 的响应式状态，适合需要细粒度更新的场景：
+
+```ts
+// 创建 store（可在任意文件中，模块级别直接调用）
+import { proxy, useSnapshot } from '@umijs/max';
+
+export const settingsStore = proxy({
+  theme: 'light' as 'light' | 'dark',
+  sidebarCollapsed: false,
+});
+
+// 组件中使用
+function ThemeToggle() {
+  const snap = useSnapshot(settingsStore);
+  return <button onClick={() => { settingsStore.theme = snap.theme === 'light' ? 'dark' : 'light'; }}>
+    当前主题: {snap.theme}
+  </button>;
+}
+```
+
 **初始状态 — getInitialState：** 在 `src/app.tsx` 中定义，全局可访问：
 
 ```tsx


### PR DESCRIPTION
## Summary

- Enable `valtio: {}` in `config/config.ts` so that `proxy`, `useSnapshot`, and other valtio APIs are available from `@umijs/max`
- Add valtio usage guide to both zh-CN and en-US cheatsheets
- Update CLAUDE.md state management section with valtio info

Fixes #11772

## Problem

When users configure `valtio: {}` in their own project config and import from `@umijs/max`, they get:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'proxy')
    at Object.proxy (.umi/exports.ts:12:10)
```

This happens because the ant-design-pro template does not enable the valtio plugin by default. Without `valtio: {}` in the config, the Umi valtio plugin is never activated, so no tmp files are generated for `plugin-valtio`, and the re-exports in `.umi/exports.ts` point to non-existent modules.

## Fix

Add `valtio: {}` to the project config so the plugin is enabled out of the box. This allows users to:

```ts
import { proxy, useSnapshot } from '@umijs/max';

const store = proxy({ count: 0 });
// useSnapshot(store) in components
```

## Test plan

- [ ] Verify `valtio: {}` appears in generated `.umi/plugin-valtio/index.ts`
- [ ] Verify `proxy`, `useSnapshot` etc. are exported from `.umi/exports.ts`
- [ ] Verify dev server starts without errors
- [ ] Verify TypeScript type checking passes (`npm run tsc`)
- [ ] Verify lint passes (`npm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Documentation**
  * 更新了开发指南，增加了响应式状态管理的最佳实践文档。
  * 发布了中英文代码示例，展示了响应式状态管理的使用方式。

* **Chores**
  * 更新了项目配置以支持新的开发工具。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->