### PR TITLE
chore(deps-dev): bump @ant-design/cli from 6.4.1 to 6.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "topojson-client": "^3.1.0"
       },
       "devDependencies": {
-        "@ant-design/cli": "^6.4.1",
+        "@ant-design/cli": "^6.4.2",
         "@biomejs/biome": "^2.4.13",
         "@commitlint/cli": "^21.0.0",
         "@commitlint/config-conventional": "^21.0.0",
@@ -128,9 +128,9 @@
       }
     },
     "node_modules/@ant-design/cli": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@ant-design/cli/-/cli-6.4.1.tgz",
-      "integrity": "sha512-vcivJbDwGiDVRcf5CAHV3nWi6Q0hGfAXcmiqPjisfqYBdY3hdQcQ7W4X5xvr63e3Fj6inN/7U2nXpY7BTozyPA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@ant-design/cli/-/cli-6.4.2.tgz",
+      "integrity": "sha512-Q87K1IU8EJAgXc1rxGSHFBolhcpwqpIpM9WFJz5M7XCjmDETojsMr5MCQmY8tFMlDu/5BWDLsjnN9WwYUOUWIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "topojson-client": "^3.1.0"
   },
   "devDependencies": {
-    "@ant-design/cli": "^6.4.1",
+    "@ant-design/cli": "^6.4.2",
     "@biomejs/biome": "^2.4.13",
     "@commitlint/cli": "^21.0.0",
     "@commitlint/config-conventional": "^21.0.0",


### PR DESCRIPTION
## Summary
- Bump `@ant-design/cli` from 6.4.1 to 6.4.2

## Test plan
- [x] `npx antd lint ./src` passes with no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 更新开发依赖版本以保持工具链最新。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ant-design/ant-design-pro/pull/11787)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->