### PR TITLE
style: update primary color to antd v6 default

### DIFF
--- a/config/defaultSettings.ts
+++ b/config/defaultSettings.ts
@@ -7,8 +7,7 @@ const Settings: ProLayoutProps & {
   logo?: string;
 } = {
   navTheme: 'light',
-  // 拂晓蓝
-  colorPrimary: '#1890ff',
+  colorPrimary: '#1677ff',
   layout: 'mix',
   contentWidth: 'Fluid',
   fixedHeader: false,


### PR DESCRIPTION
## Summary
- Update `colorPrimary` in `config/defaultSettings.ts` from `#1890ff` (antd v4 拂晓蓝) to `#1677ff` (antd v6 default).

## Test plan
- [ ] `npm start` and verify the UI uses the new primary color.
- [ ] `npm run lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Style（样式）**
  * 更新了默认主题配色，优化应用的视觉呈现效果。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ant-design/ant-design-pro/pull/11792?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->