### PR TITLE
chore: upgrade antd and related dependencies to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,15 @@
       "name": "ant-design-pro",
       "version": "6.0.1",
       "dependencies": {
-        "@ant-design/icons": "^6.2.2",
+        "@ant-design/icons": "^6.2.3",
         "@ant-design/plots": "^2.6.8",
         "@ant-design/pro-components": "^3.1.12-0",
-        "@ant-design/x": "^2.5.0",
-        "@ant-design/x-markdown": "^2.5.0",
-        "@ant-design/x-sdk": "^2.5.0",
+        "@ant-design/x": "^2.7.0",
+        "@ant-design/x-markdown": "^2.7.0",
+        "@ant-design/x-sdk": "^2.7.0",
         "@rc-component/util": "^1.11.0",
         "@tanstack/react-query": "^5.100.6",
-        "antd": "^6.4.2",
+        "antd": "^6.4.3",
         "antd-style": "^4.1.0",
         "clsx": "^2.1.1",
         "d3": "^7.9.0",
@@ -27,7 +27,7 @@
         "topojson-client": "^3.1.0"
       },
       "devDependencies": {
-        "@ant-design/cli": "^6.4.2",
+        "@ant-design/cli": "^6.4.3",
         "@biomejs/biome": "^2.4.13",
         "@commitlint/cli": "^21.0.0",
         "@commitlint/config-conventional": "^21.0.0",
@@ -128,19 +128,33 @@
       }
     },
     "node_modules/@ant-design/cli": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@ant-design/cli/-/cli-6.4.2.tgz",
-      "integrity": "sha512-Q87K1IU8EJAgXc1rxGSHFBolhcpwqpIpM9WFJz5M7XCjmDETojsMr5MCQmY8tFMlDu/5BWDLsjnN9WwYUOUWIA==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/@ant-design/cli/-/cli-6.4.3.tgz",
+      "integrity": "sha512-/fYCNzEwztc8CwyT6Ufovj3SXsQ4jjYbxa7mdazkHrzdL2xpHmQwBdmzO90LZNmHGq2J+lRuz2DR7lcjKeuRkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "oxc-parser": "^0.130.0"
+        "fast-glob": "^3.3.3",
+        "fast-levenshtein": "^3.0.0",
+        "oxc-parser": "^0.130.0",
+        "semver": "^7.8.0",
+        "string-width": "^8.2.1"
       },
       "bin": {
         "antd": "dist/index.js"
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@ant-design/cli/node_modules/fast-levenshtein": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-3.0.0.tgz",
+      "integrity": "sha512-hKKNajm46uNmTlhHSyZkmToAc56uZJwYq7yrciZjqOxnlfQwERDQJmHPUp7m1m9wx8vgOe8IaCKZ5Kv2k1DdCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fastest-levenshtein": "^1.0.7"
       }
     },
     "node_modules/@ant-design/colors": {
@@ -7100,13 +7114,13 @@
       }
     },
     "node_modules/@rc-component/notification": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@rc-component/notification/-/notification-2.0.6.tgz",
-      "integrity": "sha512-BsrVo4CBRWwG6G9HrNZtx/0PkMAZup3QAfIc7h4UdjFQfzrOKBhHuJ5c7fzUCbCSGYgAPHW9gn3sfoh+cZLSmw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@rc-component/notification/-/notification-2.0.7.tgz",
+      "integrity": "sha512-nqZzpf6BPdaj+3ILx7si79LLmqPKyUmQoXa+/9gg0SkH0v1DbD66oJgRMSBEVnd/zUT3D4gwxWIHUKebYf2ZXQ==",
       "license": "MIT",
       "dependencies": {
         "@rc-component/motion": "^1.1.4",
-        "@rc-component/util": "^1.2.1",
+        "@rc-component/util": "^1.11.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -13558,9 +13572,9 @@
       }
     },
     "node_modules/antd": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/antd/-/antd-6.4.2.tgz",
-      "integrity": "sha512-PNJz8Vxc/mC3EsOg/h3e2YuaZduJ1RDp4RmySDuDmKPCxVgyp4Da4kB36o87p9hbLbOWdAWCKQlnyopsN8utKQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/antd/-/antd-6.4.3.tgz",
+      "integrity": "sha512-6H2avkxCGfxcF67r3J2mwm9Ck50el1pks/73vfM1wDsPL/tPtj5vHuauMgJFnrqmq7CH3g8aoZ0VBQbt+jpAsw==",
       "license": "MIT",
       "dependencies": {
         "@ant-design/colors": "^8.0.1",
@@ -13585,7 +13599,7 @@
         "@rc-component/menu": "~1.3.0",
         "@rc-component/motion": "^1.3.2",
         "@rc-component/mutate-observer": "^2.0.1",
-        "@rc-component/notification": "~2.0.6",
+        "@rc-component/notification": "~2.0.7",
         "@rc-component/pagination": "~1.2.0",
         "@rc-component/picker": "~1.10.0",
         "@rc-component/progress": "~1.0.2",
@@ -13605,7 +13619,7 @@
         "@rc-component/tree-select": "~1.9.0",
         "@rc-component/trigger": "^3.9.0",
         "@rc-component/upload": "~1.1.0",
-        "@rc-component/util": "^1.10.1",
+        "@rc-component/util": "^1.11.0",
         "clsx": "^2.1.1",
         "dayjs": "^1.11.11",
         "scroll-into-view-if-needed": "^3.1.0",
@@ -30038,9 +30052,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -34,15 +34,15 @@
     "defaults"
   ],
   "dependencies": {
-    "@ant-design/icons": "^6.2.2",
+    "@ant-design/icons": "^6.2.3",
     "@ant-design/plots": "^2.6.8",
     "@ant-design/pro-components": "^3.1.12-0",
-    "@ant-design/x": "^2.5.0",
-    "@ant-design/x-markdown": "^2.5.0",
-    "@ant-design/x-sdk": "^2.5.0",
+    "@ant-design/x": "^2.7.0",
+    "@ant-design/x-markdown": "^2.7.0",
+    "@ant-design/x-sdk": "^2.7.0",
     "@rc-component/util": "^1.11.0",
     "@tanstack/react-query": "^5.100.6",
-    "antd": "^6.4.2",
+    "antd": "^6.4.3",
     "antd-style": "^4.1.0",
     "clsx": "^2.1.1",
     "d3": "^7.9.0",
@@ -53,7 +53,7 @@
     "topojson-client": "^3.1.0"
   },
   "devDependencies": {
-    "@ant-design/cli": "^6.4.2",
+    "@ant-design/cli": "^6.4.3",
     "@biomejs/biome": "^2.4.13",
     "@commitlint/cli": "^21.0.0",
     "@commitlint/config-conventional": "^21.0.0",


### PR DESCRIPTION
## Summary

- 升级 antd: ^6.4.2 → ^6.4.3
- 升级 @ant-design/icons: ^6.2.2 → ^6.2.3
- 升级 @ant-design/cli: ^6.4.2 → ^6.4.3
- 升级 @ant-design/x: ^2.5.0 → ^2.7.0
- 升级 @ant-design/x-markdown: ^2.5.0 → ^2.7.0
- 升级 @ant-design/x-sdk: ^2.5.0 → ^2.7.0

@ant-design/plots、@ant-design/pro-components、antd-style 已是最新版本，无需更新。

TypeScript 类型检查和 Biome lint 均通过。

## Test plan

- [ ] `npm run lint` 通过
- [ ] `npm run tsc` 类型检查通过
- [ ] 本地启动验证页面正常渲染

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 更新了多个设计系统及相关库的依赖版本，以获得最新的改进和优化。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ant-design/ant-design-pro/pull/11797?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->