### PR TITLE
feat: add @antv/g2 override to block compromised versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,9 @@
     "ts-node": "^10.9.2",
     "typescript": "^6.0.3"
   },
+  "overrides": {
+    "@antv/g2": ">=5.2.7 <5.5.8"
+  },
   "engines": {
     "node": ">=20.0.0"
   },


### PR DESCRIPTION
## Summary

- Add `overrides` field in `package.json` to constrain `@antv/g2` to `>=5.2.7 <5.5.8`, blocking the npm supply-chain attack versions (5.5.8, 5.6.8)

## Background

2026-05-19，npm 上多个 `@antv/*` 包遭到供应链攻击（"Mini Shai-Hulud"）。攻击者通过入侵维护者凭据，在 `preinstall` 脚本中植入凭证窃取恶意程序。

受影响版本：
- `@antv/g2` 5.5.8, 5.6.8
- `@antv/g6` 5.2.1, 5.3.1
- `@antv/x6` 3.2.7, 3.3.7
- `@antv/l7` 2.26.10, 2.27.10
- `@antv/f2` 5.16.0
- `@antv/data-set` 0.12.8, 0.13.8

## Impact Assessment

本仓库通过 `@ant-design/plots` 间接依赖 `@antv/g2@5.4.8`，**当前版本安全**。但 semver 范围 `^5.2.7` 允许 `npm install` 解析到被攻击的 5.5.8/5.6.8 版本。本仓库不依赖其他受影响包。

## Changes

在 `package.json` 中添加 `overrides` 字段，将 `@antv/g2` 限制在安全版本范围内（`>=5.2.7 <5.5.8`），防止依赖解析升级到恶意版本。等 AntV 团队发布 5.6.8 之后的清洁版本后，可放宽此限制。

## References

- https://socket.dev/blog/antv-packages-compromised
- https://github.com/antvis/G2/issues/7394

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 更新依赖版本约束配置，强制使用图表库的指定版本范围，确保项目依赖的稳定性和兼容性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ant-design/ant-design-pro/pull/11798?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->