### PR TITLE
feat: add pro-upgrade skill for AI-assisted project upgrades

### DIFF
--- a/.claude/skills/pro-upgrade/SKILL.md
+++ b/.claude/skills/pro-upgrade/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: pro-upgrade
+description: >
+  Use when the user wants to upgrade their Ant Design Pro project to the latest version.
+  Triggers on: upgrade pro, pro upgrade, migrate pro, update pro, 升级, 迁移项目,
+  "how to upgrade", "update to latest", "keep project up to date".
+allowed-tools:
+  - Bash(git clone *)
+  - Bash(diff *)
+  - Bash(npm install)
+  - Bash(npm run lint*)
+  - Bash(npm run build*)
+  - Bash(npm run tsc*)
+  - Bash(npx antd *)
+  - Bash(rm -rf /tmp/ant-design-pro-upgrade*)
+  - Read
+  - Edit
+  - Write
+  - Glob
+  - Grep
+---
+
+# Ant Design Pro Upgrade Skill
+
+You are an Ant Design Pro upgrade assistant. Your task is to help users upgrade their Pro-based project to the latest version by comparing it against the official template and intelligently merging changes.
+
+## Preflight
+
+Before starting, confirm:
+
+1. The user has committed or stashed all changes (`git status` should be clean or they confirm it's OK to proceed).
+2. If not clean, remind them: **"请先 commit 或 stash 你的更改，升级过程会修改多个文件。"** and wait for them to confirm.
+
+## Upgrade Flow
+
+### Step 1 — Fetch the latest template
+
+```bash
+rm -rf /tmp/ant-design-pro-upgrade
+git clone --depth=1 https://github.com/ant-design/ant-design-pro.git /tmp/ant-design-pro-upgrade
+```
+
+Read the template's `package.json` to confirm its version.
+
+### Step 2 — Classify files
+
+Separate the user's project files into **framework files** (Pro-owned, rarely customized) and **business files** (user-written, must be preserved).
+
+**Framework files** — diff these against the template:
+
+| Path | Notes |
+|---|---|
+| `package.json` | dependencies, scripts, devDependencies only |
+| `config/config.ts` | framework config |
+| `config/routes.ts` | structure only — preserve user-added routes |
+| `config/defaultSettings.ts` | layout/theme defaults |
+| `config/proxy.ts` | structure only — preserve user targets |
+| `src/app.tsx` | runtime config |
+| `src/access.ts` | permission definitions |
+| `src/global.tsx` | global side effects |
+| `src/loading.tsx` | loading component |
+| `src/requestErrorConfig.ts` | request interceptor |
+| `src/typings.d.ts` | global type declarations |
+| `tsconfig.json` | TypeScript config |
+| `biome.json` or `biome.jsonc` | linter config |
+| `.husky/` | git hooks |
+| `commitlint.config.*` | commit lint config |
+| `src/services/ant-design-pro/` | auto-generated — do NOT manually edit; regenerate with `npm run openapi` |
+
+**Business files** — preserve these, only adjust imports/APIs if needed:
+
+- `src/pages/**` — user pages
+- `src/components/**` — user components
+- `src/models/**` — user models
+- `src/services/*.ts` — custom service files (NOT the `ant-design-pro/` subdirectory)
+- `src/locales/**` — user translations (framework keys may need updating)
+- `src/utils/**` — user utilities
+- `mock/**` — user mocks
+- Any other files not listed above
+
+### Step 3 — Diff framework files
+
+For each framework file, read both the user's version and the template version. Identify:
+
+- **New dependencies** or version bumps in `package.json`
+- **New/changed config options** in `config/` files
+- **Import path changes** (e.g., `from 'umi'` → `from '@umijs/max'`)
+- **API changes** in `src/app.tsx`, `src/access.ts`, etc.
+- **New files** that exist in template but not in user's project
+
+### Step 4 — Merge intelligently
+
+Apply changes with these rules:
+
+**Framework files — adopt template structure, preserve user customizations:**
+- `package.json`: update dependency versions to match template. Keep any extra deps the user added. Remove deps only if the template explicitly removed them (check the template's `package.json`).
+- `config/routes.ts`: adopt the template's route structure for framework pages, but keep all user-added routes intact.
+- `config/proxy.ts`: adopt structure, preserve user's proxy targets.
+- Other framework files: adopt the template version, preserving any user customizations that are clearly intentional (comments, extra exports, business logic mixed in).
+
+**Business files — minimal changes only:**
+- Update import paths if framework modules moved (e.g., `'umi'` → `'@umijs/max'`).
+- Update deprecated API calls if the template shows a new pattern.
+- Never rewrite business logic, restructure components, or change styling approaches unless the old approach is broken.
+
+**Auto-generated files:**
+- `src/services/ant-design-pro/`: do NOT edit. Tell the user to run `npm run openapi` after upgrade.
+
+### Step 5 — Antd-specific migration checks
+
+Run these commands to catch antd API changes:
+
+```bash
+npx antd env --format json
+npx antd lint ./src --format json --only deprecated
+```
+
+If the user is upgrading across major antd versions (e.g., 5→6), also run:
+
+```bash
+npx antd migrate 5 6 --format json
+```
+
+Address any findings by updating the flagged code.
+
+### Step 6 — Install and verify
+
+```bash
+npm install
+npm run lint
+npm run build
+```
+
+Fix any errors. Common post-upgrade issues:
+- Type errors from changed APIs → check `npx antd info <Component>` for current APIs
+- New lint rules from Biome config changes → run `npm run biome` to auto-fix
+- Missing peer dependencies → check `npm install` warnings
+
+### Step 7 — Cleanup and summarize
+
+```bash
+rm -rf /tmp/ant-design-pro-upgrade
+```
+
+Output a summary of all changes made, grouped by category:
+
+1. **Dependencies updated** — list version changes
+2. **Config changes** — what changed in config files
+3. **Code patterns migrated** — import path changes, API updates
+4. **New files added** — any files from the template that didn't exist before
+5. **Manual review needed** — anything you're unsure about or that requires user action
+
+Remind the user to:
+- Run `npm run openapi` if they use the auto-generated API services
+- Test their application thoroughly
+- Commit the changes
+
+## Key Principles
+
+- **No hardcoded versions** — this skill works regardless of the version gap between the user's project and the latest template.
+- **Preserve business code** — only modify what's necessary for framework compatibility.
+- **Conservative merging** — when uncertain whether a change is a user customization or an outdated pattern, ask the user instead of guessing.
+- **Leverage `@ant-design/cli`** — use `antd migrate`, `antd lint`, `antd info` for antd-specific checks; don't guess APIs from memory.
+- **Clean up** — always remove the temporary clone directory.

--- a/.claude/skills/pro-upgrade/SKILL.md
+++ b/.claude/skills/pro-upgrade/SKILL.md
@@ -29,7 +29,7 @@ You are an Ant Design Pro upgrade assistant. Your task is to help users upgrade 
 Before starting, confirm:
 
 1. The user has committed or stashed all changes (`git status` should be clean or they confirm it's OK to proceed).
-2. If not clean, remind them: **"请先 commit 或 stash 你的更改，升级过程会修改多个文件。"** and wait for them to confirm.
+2. If not clean, remind them to commit or stash their changes first (e.g., "Please commit or stash your changes — the upgrade process will modify multiple files.") and wait for them to confirm.
 
 ## Upgrade Flow
 
@@ -72,7 +72,7 @@ Separate the user's project files into **framework files** (Pro-owned, rarely cu
 - `src/pages/**` — user pages
 - `src/components/**` — user components
 - `src/models/**` — user models
-- `src/services/*.ts` — custom service files (NOT the `ant-design-pro/` subdirectory)
+- `src/services/**/*.ts` — custom service files (NOT the `ant-design-pro/` subdirectory)
 - `src/locales/**` — user translations (framework keys may need updating)
 - `src/utils/**` — user utilities
 - `mock/**` — user mocks
@@ -93,7 +93,7 @@ For each framework file, read both the user's version and the template version. 
 Apply changes with these rules:
 
 **Framework files — adopt template structure, preserve user customizations:**
-- `package.json`: update dependency versions to match template. Keep any extra deps the user added. Remove deps only if the template explicitly removed them (check the template's `package.json`).
+- `package.json`: update dependency versions to match template. Keep any extra deps the user added. If a dependency exists in the user's project but not in the template, assume it is a user customization and preserve it.
 - `config/routes.ts`: adopt the template's route structure for framework pages, but keep all user-added routes intact.
 - `config/proxy.ts`: adopt structure, preserve user's proxy targets.
 - Other framework files: adopt the template version, preserving any user customizations that are clearly intentional (comments, extra exports, business logic mixed in).
@@ -115,11 +115,13 @@ npx antd env --format json
 npx antd lint ./src --format json --only deprecated
 ```
 
-If the user is upgrading across major antd versions (e.g., 5→6), also run:
+If the user is upgrading across major antd versions, also run:
 
 ```bash
-npx antd migrate 5 6 --format json
+npx antd migrate <current_major> <target_major> --format json
 ```
+
+Detect the current major version from the user's `package.json` and the target from the template's.
 
 Address any findings by updating the flagged code.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,1 @@
-# AGENTS.md
-
-This file provides guidance for AI coding agents when working with code in this repository.
-
-For full project guidance, see [CLAUDE.md](./CLAUDE.md).
+CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,3 @@
 This file provides guidance for AI coding agents when working with code in this repository.
 
 For full project guidance, see [CLAUDE.md](./CLAUDE.md).
-
-## Upgrading
-
-To upgrade this project to the latest Ant Design Pro version, follow the instructions in [.claude/skills/pro-upgrade/SKILL.md](./.claude/skills/pro-upgrade/SKILL.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,7 @@
 This file provides guidance for AI coding agents when working with code in this repository.
 
 For full project guidance, see [CLAUDE.md](./CLAUDE.md).
+
+## Upgrading
+
+To upgrade this project to the latest Ant Design Pro version, follow the instructions in [.claude/skills/pro-upgrade/SKILL.md](./.claude/skills/pro-upgrade/SKILL.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,10 @@ Other: `npm run openapi` (regenerate `src/services/`), `npm run simple` (**irrev
 
 **Cloudflare Worker**: `cloudflare-worker/` — separate Hono app, own `package.json`, not an npm workspace.
 
+## Upgrading
+
+Run `/pro-upgrade` in Claude Code to auto-upgrade the project to the latest Ant Design Pro version. It diffs the latest template against this project and merges framework changes while preserving business code. Works for any version gap (v5→v6, v6.x→latest, etc.).
+
 ## Page Co-location
 
 Each page dir: `index.tsx`, optional `service.ts`, `_mock.ts`, `data.d.ts`, style files. Keep page-specific code with the page.

--- a/docs/cheatsheet.en-US.md
+++ b/docs/cheatsheet.en-US.md
@@ -495,8 +495,7 @@ Create a file in `src/models/` exporting a custom Hook, then use `useModel('file
 **Q: How to upgrade the project?**
 First, install the pro-upgrade skill into your project:
 ```bash
-mkdir -p .claude/skills/pro-upgrade
-curl -sL https://raw.githubusercontent.com/ant-design/ant-design-pro/master/.claude/skills/pro-upgrade/SKILL.md -o .claude/skills/pro-upgrade/SKILL.md
+npx skills add ant-design/ant-design-pro
 ```
 Then run `/pro-upgrade` in Claude Code at the project root — AI will auto-diff the latest template and upgrade your project (deps, config, code patterns, etc.). For other AI assistants, paste the content of `.claude/skills/pro-upgrade/SKILL.md` to them.
 

--- a/docs/cheatsheet.en-US.md
+++ b/docs/cheatsheet.en-US.md
@@ -493,7 +493,12 @@ Edit `colorPrimary` in `config/defaultSettings.ts`. Use SettingDrawer for live p
 Create a file in `src/models/` exporting a custom Hook, then use `useModel('filename')` in components.
 
 **Q: How to upgrade the project?**
-Run `/pro-upgrade` in Claude Code at the project root — AI will auto-diff the latest Ant Design Pro template and upgrade your project (deps, config, code patterns, etc.). For other AI assistants, paste the content from `AGENTS.md`.
+First, install the pro-upgrade skill into your project:
+```bash
+mkdir -p .claude/skills/pro-upgrade
+curl -sL https://raw.githubusercontent.com/ant-design/ant-design-pro/master/.claude/skills/pro-upgrade/SKILL.md -o .claude/skills/pro-upgrade/SKILL.md
+```
+Then run `/pro-upgrade` in Claude Code at the project root — AI will auto-diff the latest template and upgrade your project (deps, config, code patterns, etc.). For other AI assistants, paste the content of `.claude/skills/pro-upgrade/SKILL.md` to them.
 
 **Q: How to deploy?**
 `npm run build` generates `dist/`. Deploy to any static file server. Set `publicPath` for non-root deployments. `npm run deploy` builds and publishes to GitHub Pages automatically (pushes to gh-pages branch).

--- a/docs/cheatsheet.en-US.md
+++ b/docs/cheatsheet.en-US.md
@@ -492,6 +492,9 @@ Edit `colorPrimary` in `config/defaultSettings.ts`. Use SettingDrawer for live p
 **Q: How to add global state?**
 Create a file in `src/models/` exporting a custom Hook, then use `useModel('filename')` in components.
 
+**Q: How to upgrade the project?**
+Run `/pro-upgrade` in Claude Code at the project root — AI will auto-diff the latest Ant Design Pro template and upgrade your project (deps, config, code patterns, etc.). For other AI assistants, paste the content from `AGENTS.md`.
+
 **Q: How to deploy?**
 `npm run build` generates `dist/`. Deploy to any static file server. Set `publicPath` for non-root deployments. `npm run deploy` builds and publishes to GitHub Pages automatically (pushes to gh-pages branch).
 

--- a/docs/cheatsheet.en-US.md
+++ b/docs/cheatsheet.en-US.md
@@ -497,7 +497,7 @@ First, install the pro-upgrade skill into your project:
 ```bash
 npx skills add ant-design/ant-design-pro
 ```
-Then run `/pro-upgrade` in Claude Code at the project root — AI will auto-diff the latest template and upgrade your project (deps, config, code patterns, etc.). For other AI assistants, paste the content of `.claude/skills/pro-upgrade/SKILL.md` to them.
+Then run `/pro-upgrade` in Claude Code at the project root — AI will auto-diff the latest template and assist your upgrade (deps, config, code patterns, etc.), with conservative handling for ambiguous merges. For other AI assistants, paste the content of `.claude/skills/pro-upgrade/SKILL.md` to them.
 
 **Q: How to deploy?**
 `npm run build` generates `dist/`. Deploy to any static file server. Set `publicPath` for non-root deployments. `npm run deploy` builds and publishes to GitHub Pages automatically (pushes to gh-pages branch).

--- a/docs/cheatsheet.zh-CN.md
+++ b/docs/cheatsheet.zh-CN.md
@@ -492,6 +492,9 @@ export default {
 **Q: 如何添加全局状态？**
 在 `src/models/` 下创建文件，导出自定义 Hook，组件中通过 `useModel('文件名')` 使用。
 
+**Q: 如何升级项目？**
+在项目根目录用 Claude Code 运行 `/pro-upgrade`，AI 会自动对比最新 Ant Design Pro 模板并完成升级（依赖、配置、代码模式等）。如使用其他 AI 助手，可将 `AGENTS.md` 中的内容提供给它。
+
 **Q: 如何部署？**
 `npm run build` 生成 `dist/` 目录，部署到任意静态服务器。配置 `publicPath` 处理非根目录部署。`npm run deploy` 会自动构建并发布到 GitHub Pages（推送到 gh-pages 分支）。
 

--- a/docs/cheatsheet.zh-CN.md
+++ b/docs/cheatsheet.zh-CN.md
@@ -497,7 +497,7 @@ export default {
 ```bash
 npx skills add ant-design/ant-design-pro
 ```
-然后在项目根目录用 Claude Code 运行 `/pro-upgrade`，AI 会自动对比最新模板并完成升级（依赖、配置、代码模式等）。如使用其他 AI 助手，可将 `.claude/skills/pro-upgrade/SKILL.md` 中的内容提供给它。
+然后在项目根目录用 Claude Code 运行 `/pro-upgrade`，AI 会自动对比最新模板并辅助完成升级（依赖、配置、代码模式等），遇到冲突时会保守处理并询问确认。如使用其他 AI 助手，可将 `.claude/skills/pro-upgrade/SKILL.md` 中的内容提供给它。
 
 **Q: 如何部署？**
 `npm run build` 生成 `dist/` 目录，部署到任意静态服务器。配置 `publicPath` 处理非根目录部署。`npm run deploy` 会自动构建并发布到 GitHub Pages（推送到 gh-pages 分支）。

--- a/docs/cheatsheet.zh-CN.md
+++ b/docs/cheatsheet.zh-CN.md
@@ -493,7 +493,12 @@ export default {
 在 `src/models/` 下创建文件，导出自定义 Hook，组件中通过 `useModel('文件名')` 使用。
 
 **Q: 如何升级项目？**
-在项目根目录用 Claude Code 运行 `/pro-upgrade`，AI 会自动对比最新 Ant Design Pro 模板并完成升级（依赖、配置、代码模式等）。如使用其他 AI 助手，可将 `AGENTS.md` 中的内容提供给它。
+先将 pro-upgrade skill 安装到项目中：
+```bash
+mkdir -p .claude/skills/pro-upgrade
+curl -sL https://raw.githubusercontent.com/ant-design/ant-design-pro/master/.claude/skills/pro-upgrade/SKILL.md -o .claude/skills/pro-upgrade/SKILL.md
+```
+然后在项目根目录用 Claude Code 运行 `/pro-upgrade`，AI 会自动对比最新模板并完成升级（依赖、配置、代码模式等）。如使用其他 AI 助手，可将 `.claude/skills/pro-upgrade/SKILL.md` 中的内容提供给它。
 
 **Q: 如何部署？**
 `npm run build` 生成 `dist/` 目录，部署到任意静态服务器。配置 `publicPath` 处理非根目录部署。`npm run deploy` 会自动构建并发布到 GitHub Pages（推送到 gh-pages 分支）。

--- a/docs/cheatsheet.zh-CN.md
+++ b/docs/cheatsheet.zh-CN.md
@@ -495,8 +495,7 @@ export default {
 **Q: 如何升级项目？**
 先将 pro-upgrade skill 安装到项目中：
 ```bash
-mkdir -p .claude/skills/pro-upgrade
-curl -sL https://raw.githubusercontent.com/ant-design/ant-design-pro/master/.claude/skills/pro-upgrade/SKILL.md -o .claude/skills/pro-upgrade/SKILL.md
+npx skills add ant-design/ant-design-pro
 ```
 然后在项目根目录用 Claude Code 运行 `/pro-upgrade`，AI 会自动对比最新模板并完成升级（依赖、配置、代码模式等）。如使用其他 AI 助手，可将 `.claude/skills/pro-upgrade/SKILL.md` 中的内容提供给它。
 


### PR DESCRIPTION
## Summary

- Add `.claude/skills/pro-upgrade/SKILL.md` — a Claude Code skill that enables AI agents to upgrade Ant Design Pro projects by diffing the latest template and intelligently merging framework changes while preserving business code
- Update `CLAUDE.md` with an Upgrading section referencing the skill
- Update `AGENTS.md` with a link to the skill for Codex compatibility

The skill works for any version gap (v5→v6, v6.x→latest, etc.) by cloning the latest template, classifying files into framework vs business, diffing framework files, and merging intelligently with conservative defaults.

Closes #11800

## Test plan

- [ ] Verify `/pro-upgrade` skill triggers correctly in Claude Code
- [ ] Verify AGENTS.md link resolves correctly for Codex
- [ ] Test the skill on a v5-based project to confirm it identifies and applies migrations correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 新增一份详尽的项目升级技能文档，描述自动化对比模板、保留业务代码、合并框架变更与校验流程
  * 在主文档中加入“升级”章节，说明通过自动化命令辅助跨版本升级的流程与注意事项
  * 在中/英常见问题中新增“如何升级项目”的操作指南与使用说明

* **Chores**
  * 移除已废弃的代理使用说明文档

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ant-design/ant-design-pro/pull/11801?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->