### PR TITLE
chore: pin GitHub Actions to commit SHAs and configure dependabot for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,12 @@ updates:
       dependencies:
         patterns:
           - '*'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 20
       - run: npm ci
@@ -23,13 +23,13 @@ jobs:
         node_version: [20]
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Use Node.js ${{ matrix.node_version }}
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: ${{ matrix.node_version }}
       - run: echo ${{github.ref}}
-      - uses: utooland/setup-utoo@v1
+      - uses: utooland/setup-utoo@3a51006d0b66afcc32d1b9177a4b200b74f4a8cb # v1
         with:
           cache-utoo: false
       - run: ut

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,13 +9,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Use Node.js 20
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 20
       - run: echo ${{github.ref}}
-      - uses: utooland/setup-utoo@v1
+      - uses: utooland/setup-utoo@3a51006d0b66afcc32d1b9177a4b200b74f4a8cb # v1
       - run: ut
       - run: ut test:coverage
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,16 +15,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: utooland/setup-utoo@v1
+      - uses: utooland/setup-utoo@3a51006d0b66afcc32d1b9177a4b200b74f4a8cb # v1
       - run: ut
       - name: Set COMMIT_HASH
         run: echo "COMMIT_HASH=${{ github.sha }}" >> $GITHUB_ENV
       - run: ut build
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist

--- a/.github/workflows/emoji-helper.yml
+++ b/.github/workflows/emoji-helper.yml
@@ -11,7 +11,7 @@ jobs:
   emoji:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-cool/emoji-helper@v1.0.0
+      - uses: actions-cool/emoji-helper@040b841cb25e2e6f50151c73b5ce12fee57019d2 # v1.0.0
         with:
           type: 'release'
           emoji: '+1, laugh, heart, hooray, rocket, eyes'

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: help wanted
         if: github.event.label.name == '❤️ help wanted' || github.event.label.name == '🤝Welcome PR'
-        uses: actions-cool/issues-helper@v1.11
+        uses: actions-cool/issues-helper@v1.11 # repo blocked, unable to pin to SHA
         with:
           actions: 'create-comment'
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -27,7 +27,7 @@ jobs:
 
       - name: Need Reproduce
         if: github.event.label.name == '🤔 Need Reproduce'
-        uses: actions-cool/issues-helper@v1.11
+        uses: actions-cool/issues-helper@v1.11 # repo blocked, unable to pin to SHA
         with:
           actions: 'create-comment'
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -12,18 +12,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - uses: utooland/setup-utoo@v1
+      - uses: utooland/setup-utoo@3a51006d0b66afcc32d1b9177a4b200b74f4a8cb # v1
       - run: ut
       - name: Set COMMIT_HASH
         run: echo "COMMIT_HASH=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
       - run: ut build
 
       - name: upload dist artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: dist
           path: dist/
@@ -35,7 +35,7 @@ jobs:
 
       - name: Upload PR number
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pr
           path: ./pr-id.txt

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -19,7 +19,7 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     steps:
       - name: download pr artifact
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
         with:
           workflow: ${{ github.event.workflow_run.workflow_id }}
           name: pr
@@ -36,7 +36,7 @@ jobs:
           echo "id=$PR_ID" >> "$GITHUB_OUTPUT"
 
       - name: download dist artifact
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
         with:
           workflow: ${{ github.event.workflow_run.workflow_id }}
           workflow_conclusion: success
@@ -49,7 +49,7 @@ jobs:
           npx surge --project ./ --domain $DEPLOY_DOMAIN --token ${{ secrets.SURGE_TOKEN }}
 
       - name: update status comment
-        uses: actions-cool/maintain-one-comment@v1.2.1
+        uses: actions-cool/maintain-one-comment@v1.2.1 # repo blocked, unable to pin to SHA
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: |
@@ -63,7 +63,7 @@ jobs:
 
       - name: The job failed
         if: ${{ failure() }}
-        uses: actions-cool/maintain-one-comment@v1.2.1
+        uses: actions-cool/maintain-one-comment@v1.2.1 # repo blocked, unable to pin to SHA
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: |
@@ -84,7 +84,7 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'failure'
     steps:
       - name: download pr artifact
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
         with:
           workflow: ${{ github.event.workflow_run.workflow_id }}
           name: pr
@@ -101,7 +101,7 @@ jobs:
           echo "id=$PR_ID" >> "$GITHUB_OUTPUT"
 
       - name: The job failed
-        uses: actions-cool/maintain-one-comment@v1.2.1
+        uses: actions-cool/maintain-one-comment@v1.2.1 # repo blocked, unable to pin to SHA
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: |

--- a/.github/workflows/preview-start.yml
+++ b/.github/workflows/preview-start.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: create
-        uses: actions-cool/maintain-one-comment@v1.2.1
+        uses: actions-cool/maintain-one-comment@v1.2.1 # repo blocked, unable to pin to SHA
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: |

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -10,11 +10,11 @@ jobs:
   react-doctor:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
-      - uses: millionco/react-doctor@main
+      - uses: millionco/react-doctor@6543a86f9dfe86c894bd71361fc2c46d8d9c967d # main
         with:
           diff: true
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions to immutable commit SHAs with version tag comments for supply chain security
- Add `github-actions` ecosystem to dependabot.yml with **weekly** schedule and **grouped** updates

### Pinned actions

| Action | Before | After |
|--------|--------|-------|
| actions/checkout | `@v6` | `@de0fac2e` |
| actions/setup-node | `@v5` | `@a0853c2` |
| utooland/setup-utoo | `@v1` | `@3a51006` |
| codecov/codecov-action | `@v5` | `@75cd116` |
| peaceiris/actions-gh-pages | `@v4` | `@4f9cc66` |
| actions/upload-artifact | `@v4` | `@ea165f8` |
| dawidd6/action-download-artifact | `@v6` | `@bf251b5` |
| actions-cool/emoji-helper | `@v1.0.0` | `@040b841` |
| millionco/react-doctor | `@main` | `@6543a86` |

### Could not pin (repo blocked by GitHub TOS)

- `actions-cool/issues-helper@v1.11` — repo access blocked
- `actions-cool/maintain-one-comment@v1.2.1` — repo access blocked

### Dependabot config

Added `github-actions` ecosystem with:
- Schedule: weekly (changed from default)
- Grouping: all GitHub Actions updates grouped into one PR

## Test plan

- [ ] Verify CI workflow runs correctly with pinned SHAs
- [ ] Verify dependabot creates a grouped PR for GitHub Actions updates on the weekly schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 优化了构建和部署流程的依赖配置，将多个 GitHub Actions 固定为特定版本以提高构建稳定性和可重复性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ant-design/ant-design-pro/pull/11803?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->