### PR TITLE
docs: add v6.1.0 release plan

### DIFF
--- a/docs/roadmap/v6.1.0-release-plan.md
+++ b/docs/roadmap/v6.1.0-release-plan.md
@@ -1,0 +1,149 @@
+# Ant Design Pro v6.1.0 Release Plan
+
+**Date**: 2026-06-01
+**Status**: Draft
+**Approach**: Layered progression — cleanup first, then engineering, then upgrades
+
+## Overview
+
+v6.1.0 is a quality + upgrade release focusing on test infrastructure, bug fixes, legacy cleanup, and dependency alignment. Breaking changes are allowed where justified with migration notes.
+
+## Layer 1: Cleanup & Bug Fixes
+
+### 1.2 Clean up `ant-legacy-form-item` CSS class references
+
+antd v6 removed these legacy class names. Three files still reference them:
+
+- `src/components/StandardFormRow/index.style.ts` (8 references)
+- `src/pages/form/advanced-form/style.style.ts` (1 reference)
+- `src/pages/account/settings/components/index.style.ts` (1 reference)
+
+**Action**: Replace `.ant-legacy-form-item` selectors with current antd v6 equivalents (`.ant-form-item`). Verify visual parity after changes.
+
+### 1.3 Clean up typings.d.ts legacy module declarations
+
+`src/typings.d.ts` declares modules for `slash2` and `omit.js` — v5-era dependencies no longer in use.
+
+**Action**: Grep for actual imports. If none found, remove the declarations.
+
+### 1.4 Bug fixes
+
+| # | Issue | Description | Approach |
+|---|-------|-------------|----------|
+| 1 | #11772 | valtio undefined error | Trace dependency chain; fix initialization or remove unused valtio import |
+| 2 | #11764 | OpenAPI link text visible in collapsed sidebar | CSS fix to hide text or truncate when sidebar is collapsed |
+| 3 | #11747 | Windows 11 "Can't resolve 'tailwindcss'" | Investigate path resolution; likely needs module resolution config fix |
+| 4 | #11575 | OpenAPI generated file first-letter case inconsistency | Review openapi config `camel2Line`/naming options; add normalization |
+| 5 | #11286 | Language switcher cannot be disabled in non-mix layouts | Fix `disableLocal` prop propagation in layout config |
+| 6 | #11597 | Mask layer bug with pagination and sidebar | z-index / overlay stacking fix |
+
+### 1.5 Clean up request interceptor demo placeholder
+
+`src/requestErrorConfig.ts` appends `?token=123` to every request URL as a demo artifact.
+
+**Action**: Replace with commented example or conditional (dev-only) guard. Do not remove the pattern entirely — it serves as a reference for token attachment.
+
+## Layer 2: Testing & Engineering
+
+### 2.1 Migrate Jest → Vitest (#11742)
+
+**Rationale**: Vitest offers native ESM, instant HMR, and Vite-native config. Jest startup is slow and ESM support is fragile.
+
+**Steps**:
+1. Add `vitest` and `@vitest/coverage-v8` dependencies
+2. Create `vitest.config.ts` using Umi plugin compatibility
+3. Migrate `tests/` setup files (`setupTests.jsx`, `__mocks__/`)
+4. Migrate `src/pages/user/login/login.test.tsx` → Vitest syntax
+5. Update `package.json` scripts: `test`, `test:coverage`, `test:ui`
+6. Remove Jest dependencies: `jest`, `@testing-library/jest-dom`, related config
+7. Verify CI pipeline
+
+**Breaking change**: Test authoring API changes (minimal — Vitest is Jest-compatible).
+
+### 2.2 Expand test coverage
+
+Current: 1 test file, 2 test cases, ~1% file coverage.
+
+**Priority test targets**:
+
+| Target | File | What to test |
+|--------|------|--------------|
+| ProTable page | `src/pages/list/table-list/index.tsx` | Data loading, search, pagination, CRUD operations |
+| Dashboard | `src/pages/dashboard/analysis/index.tsx` | Chart rendering, layout, chart data flow |
+| Basic form | `src/pages/form/basic-form/index.tsx` | Form validation, submission, field interactions |
+| Auth flow | `src/access.ts`, `src/app.tsx` | `canAdmin` logic, `getInitialState` 401 redirect |
+| Request interceptor | `src/requestErrorConfig.ts` | Error handling paths, 401 redirect, token attachment |
+
+**Coverage target**: Core pages 50%+, overall 20%+.
+
+### 2.3 CI pipeline optimization
+
+- Enable GitHub Actions cache for `node_modules` and build output
+- Parallelize PR checks: lint | typecheck | test (instead of sequential)
+- Evaluate Codecov upload — remove if coverage data remains below actionable threshold
+
+### 2.4 Code quality enforcement
+
+- Add `npx antd lint ./src` to CI pipeline (currently only enforced manually)
+- Tighten Biome rules: audit warnings and elevate to errors where appropriate
+
+## Layer 3: Dependency Upgrades
+
+### 3.1 Core dependencies
+
+| Package | From | To | Risk |
+|---------|------|----|------|
+| antd | ^6.4.3 | 6.x latest | Low |
+| @ant-design/pro-components | ^3.1.12-0 | 3.x stable | Low |
+| @ant-design/x | ^2.7.0 | 2.x latest | Low |
+| @ant-design/x-markdown | ^2.7.0 | 2.x latest | Low |
+| @ant-design/x-sdk | ^2.7.0 | 2.x latest | Low |
+| @umijs/max | ^4.6.51 | 4.x latest | Medium — check breaking notes |
+| React / React DOM | ^19.2.5 | Stay (React 20 not released) | — |
+
+### 3.2 Toolchain dependencies
+
+| Package | From | To |
+|---------|------|----|
+| TypeScript | ^6.0.3 | 6.x latest |
+| Biome | ^2.4.13 | 2.x latest |
+| Tailwind CSS | ^4.2.4 | 4.x latest |
+| Express (mock) | ^5.2.1 | 5.x latest |
+| @tanstack/react-query | ^5.100.6 | 5.x latest |
+| d3 | ^7.9.0 | 7.x latest or evaluate alternatives |
+
+### 3.3 Evaluation items (investigate before upgrading)
+
+- **Node.js 22**: Currently requires >= 20. Assess whether raising to >= 22 is warranted.
+- **utoopack**: Check for significant updates or breaking changes in the build toolchain.
+- **@tanstack/react-query v6**: If released, evaluate migration path.
+
+### 3.4 Post-upgrade validation checklist
+
+- [ ] `npm run lint` passes (Biome + tsc)
+- [ ] `npx antd lint ./src` passes
+- [ ] `npm run build` succeeds
+- [ ] All tests pass
+- [ ] `npm start` dev server works
+- [ ] Visual spot-check of key pages (login, dashboard, table-list, forms)
+- [ ] Update CLAUDE.md if version requirements change
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Umi Max upgrade breaks build | Medium | High | Pin version; test in CI before merge |
+| Vitest + Umi plugin compatibility | Medium | Medium | Research existing Umi + Vitest integrations; may need adapter |
+| Windows compatibility regression | Low | Medium | Test on Windows or add Windows CI |
+| antd v6 minor API changes | Low | Low | Review antd changelog; run `npx antd lint` |
+| Test coverage effort exceeds estimate | Medium | Low | Prioritize core pages; defer edge cases |
+
+## Execution Order
+
+```
+Layer 1 (cleanup + bugs) → Layer 2 (testing) → Layer 3 (upgrades)
+```
+
+Each layer produces a shippable state. If time constrains, lower layers deliver more value per effort.
+
+Within each layer, items can be parallelized across contributors.


### PR DESCRIPTION
Add the v6.1.0 release plan design spec to `docs/roadmap/v6.1.0-release-plan.md`. Closes #11813 (tracking issue).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 新增 v6.1.0 版本发布计划，包含发布时间表、三层执行策略（遗留清理、测试工程改造、依赖升级）及风险评估。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->