### PR TITLE
fix: remove legacy ant-legacy-form-item CSS class references

### DIFF
--- a/src/components/StandardFormRow/index.style.ts
+++ b/src/components/StandardFormRow/index.style.ts
@@ -50,10 +50,10 @@ const useStyles = createStyles(({ token }) => {
       border: 'none',
     },
     standardFormRowBlock: {
-      '.ant-form-item, div.ant-form-item-control-wrapper': { display: 'block' },
+      '.ant-form-item, div.ant-form-item-control': { display: 'block' },
     },
     standardFormRowGrid: {
-      '.ant-form-item, div.ant-form-item-control-wrapper': { display: 'block' },
+      '.ant-form-item, div.ant-form-item-control': { display: 'block' },
       '.ant-form-item-label': { float: 'left' },
     },
   };

--- a/src/components/StandardFormRow/index.style.ts
+++ b/src/components/StandardFormRow/index.style.ts
@@ -8,15 +8,17 @@ const useStyles = createStyles(({ token }) => {
       marginBottom: '16px',
       paddingBottom: '16px',
       borderBottom: `1px dashed ${token.colorSplit}`,
-      '.ant-form-item, .ant-legacy-form-item': { marginRight: '24px' },
-      '.ant-form-item-label, .ant-legacy-form-item-label': {
+      '.ant-form-item': { marginRight: '24px' },
+      '.ant-form-item-label': {
         label: {
           marginRight: '0',
           color: token.colorText,
         },
       },
-      '.ant-form-item-label, .ant-legacy-form-item-label, .ant-form-item-control, .ant-legacy-form-item-control':
-        { padding: '0', lineHeight: '32px' },
+      '.ant-form-item-label, .ant-form-item-control': {
+        padding: '0',
+        lineHeight: '32px',
+      },
     },
     label: {
       flex: '0 0 auto',
@@ -35,7 +37,7 @@ const useStyles = createStyles(({ token }) => {
     },
     content: {
       flex: '1 1 0',
-      '.ant-form-item, .ant-legacy-form-item': {
+      '.ant-form-item': {
         '&:last-child': {
           display: 'block',
           marginRight: '0',
@@ -48,13 +50,11 @@ const useStyles = createStyles(({ token }) => {
       border: 'none',
     },
     standardFormRowBlock: {
-      '.ant-form-item, .ant-legacy-form-item, div.ant-form-item-control-wrapper, div.ant-legacy-form-item-control-wrapper':
-        { display: 'block' },
+      '.ant-form-item, div.ant-form-item-control-wrapper': { display: 'block' },
     },
     standardFormRowGrid: {
-      '.ant-form-item, .ant-legacy-form-item, div.ant-form-item-control-wrapper, div.ant-legacy-form-item-control-wrapper':
-        { display: 'block' },
-      '.ant-form-item-label, .ant-legacy-form-item-label': { float: 'left' },
+      '.ant-form-item, div.ant-form-item-control-wrapper': { display: 'block' },
+      '.ant-form-item-label': { float: 'left' },
     },
   };
 });

--- a/src/pages/account/settings/components/index.style.ts
+++ b/src/pages/account/settings/components/index.style.ts
@@ -5,7 +5,7 @@ const useStyles = createStyles(({ token }) => {
     baseView: {
       display: 'flex',
       paddingTop: '12px',
-      '.ant-form-item .ant-form-item-control-wrapper': {
+      '.ant-form-item .ant-form-item-control': {
         width: '100%',
       },
       [`@media screen and (max-width: ${token.screenXL}px)`]: {

--- a/src/pages/account/settings/components/index.style.ts
+++ b/src/pages/account/settings/components/index.style.ts
@@ -5,7 +5,7 @@ const useStyles = createStyles(({ token }) => {
     baseView: {
       display: 'flex',
       paddingTop: '12px',
-      '.ant-legacy-form-item .ant-legacy-form-item-control-wrapper': {
+      '.ant-form-item .ant-form-item-control-wrapper': {
         width: '100%',
       },
       [`@media screen and (max-width: ${token.screenXL}px)`]: {

--- a/src/pages/form/advanced-form/style.style.ts
+++ b/src/pages/form/advanced-form/style.style.ts
@@ -4,7 +4,7 @@ const useStyles = createStyles(({ token }) => {
   return {
     card: {
       marginBottom: '24px',
-      '.ant-form-item .ant-form-item-control-wrapper': {
+      '.ant-form-item .ant-form-item-control': {
         width: '100%',
       },
     },

--- a/src/pages/form/advanced-form/style.style.ts
+++ b/src/pages/form/advanced-form/style.style.ts
@@ -4,7 +4,7 @@ const useStyles = createStyles(({ token }) => {
   return {
     card: {
       marginBottom: '24px',
-      '.ant-legacy-form-item .ant-legacy-form-item-control-wrapper': {
+      '.ant-form-item .ant-form-item-control-wrapper': {
         width: '100%',
       },
     },


### PR DESCRIPTION
Replace `.ant-legacy-form-item` selectors with `.ant-form-item` in StandardFormRow, advanced-form, and account settings styles. These legacy class names were removed in antd v6. Closes #11814.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 更新表单相关样式以兼容最新 Ant Design DOM：移除 legacy 覆盖、改用当前选择器，调整表单项的外边距、文字颜色、内间距、行高、宽度与浮动规则，确保在新版组件下表单布局和控件宽度正确呈现。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->