### PR TITLE
fix: remove unused slash2 and omit.js module declarations

### DIFF
--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,4 +1,3 @@
-declare module 'slash2';
 declare module '*.css';
 declare module '*.less';
 declare module '*.scss';
@@ -14,7 +13,6 @@ declare module '*.md' {
   const content: string;
   export default content;
 }
-declare module 'omit.js';
 declare module 'mockjs';
 
 declare const __APP_VERSION__: string;


### PR DESCRIPTION
These v5-era dependencies are no longer imported anywhere. Closes #11815.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **重构**
  * 清理了不再使用的模块声明。
  * 新增版本常量声明以支持应用版本追踪。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->