### PR TITLE
fix: replace hardcoded demo token in request interceptor

### DIFF
--- a/src/requestErrorConfig.ts
+++ b/src/requestErrorConfig.ts
@@ -94,8 +94,12 @@ export const errorConfig: RequestConfig = {
   requestInterceptors: [
     (config: RequestOptions) => {
       // 拦截请求配置，进行个性化处理。
-      const url = config?.url?.concat('?token=123');
-      return { ...config, url };
+      // 示例：为请求附加 token（按需启用）
+      // const token = localStorage.getItem('token');
+      // if (token) {
+      //   config.headers = { ...config.headers, Authorization: `Bearer ${token}` };
+      // }
+      return config;
     },
   ],
 


### PR DESCRIPTION
Remove the `?token=123` demo placeholder from requestErrorConfig.ts. Replace with commented Bearer token example. Closes #11822.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 移除了请求中自动追加固定token参数的行为，请求现在将按预期发送，无多余参数附加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->