### PR TITLE
fix: hide sidebar link text when collapsed

### DIFF
--- a/src/global.less
+++ b/src/global.less
@@ -61,6 +61,10 @@ body,
   left: unset;
 }
 
+.ant-pro-sider-collapsed .ant-pro-sider-link span:not([role='img']) {
+  display: none;
+}
+
 canvas {
   display: block;
 }

--- a/src/global.style.ts
+++ b/src/global.style.ts
@@ -11,7 +11,7 @@ const useStyles = createStyles(() => {
     'ant-pro-sider.ant-layout-sider.ant-pro-sider-fixed': {
       left: 'unset',
     },
-    'ant-pro-sider-collapsed .ant-pro-sider-link span:not([role="img"])': {
+    '.ant-pro-sider-collapsed .ant-pro-sider-link span:not([role="img"])': {
       display: 'none',
     },
     canvas: {

--- a/src/global.style.ts
+++ b/src/global.style.ts
@@ -11,6 +11,9 @@ const useStyles = createStyles(() => {
     'ant-pro-sider.ant-layout-sider.ant-pro-sider-fixed': {
       left: 'unset',
     },
+    'ant-pro-sider-collapsed .ant-pro-sider-link span:not([role="img"])': {
+      display: 'none',
+    },
     canvas: {
       display: 'block',
     },


### PR DESCRIPTION
Add CSS rule to hide link text in collapsed ProLayout sidebar. Closes #11764.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **样式**
  * 在侧边栏折叠时，隐藏菜单项中非图标的文本标签，只保留图标显示，提升折叠模式下的界面整洁性与可读性。此改动仅影响展示样式，不改变功能或交互行为；已应用于全局样式配置，影响范围有限，无需额外手动配置。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->