### PR TITLE
fix: disable unused valtio plugin to resolve undefined error

### DIFF
--- a/config/config.ts
+++ b/config/config.ts
@@ -104,6 +104,7 @@ export default defineConfig({
    * @@doc https://umijs.org/docs/max/data-flow
    */
   model: {},
+  valtio: false,
   /**
    * 一个全局的初始数据流，可以用它在插件之间共享数据
    * @description 可以用来存放一些全局的数据，比如用户信息，或者一些全局的状态，全局初始状态在整个 Umi 项目的最开始创建。


### PR DESCRIPTION
Umi Max auto-enables the valtio plugin, which is not used in this project. This causes `valtio is undefined` errors at runtime. Explicitly disable it with `valtio: false` in the config. Closes #11817.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 在项目配置中显式将 valtio 数据流插件设置为 false，关闭默认启用的 valtio 插件以避免在未使用情况下意外启用带来的运行时问题，并保持其余配置不变以确保配置行为可预测。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->