### PR TITLE
fix: respect layout.locale setting to hide language switcher

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -88,11 +88,15 @@ export const layout: RunTimeLayoutConfig = ({
       }
       return dom;
     },
-    actionsRender: () => [
-      <DocLink key="doc" />,
-      <VersionDropdown key="version" />,
-      <LangDropdown key="lang" />,
-    ],
+    actionsRender: () => {
+      const localeEnabled =
+        (initialState?.settings as Record<string, unknown>)?.locale !== false;
+      return [
+        <DocLink key="doc" />,
+        <VersionDropdown key="version" />,
+        localeEnabled && <LangDropdown key="lang" />,
+      ].filter(Boolean);
+    },
     avatarProps: {
       src: initialState?.currentUser?.avatar,
       title: 'ProUser',

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -89,8 +89,10 @@ export const layout: RunTimeLayoutConfig = ({
       return dom;
     },
     actionsRender: () => {
+      // `locale: false` opts out of the language switcher. ProLayout's own
+      // `locale` prop is a locale string, so narrow to the boolean toggle here.
       const localeEnabled =
-        (initialState?.settings as Record<string, unknown>)?.locale !== false;
+        (initialState?.settings as { locale?: boolean })?.locale !== false;
       return [
         <DocLink key="doc" />,
         <VersionDropdown key="version" />,


### PR DESCRIPTION
When `layout.locale` is set to `false`, the language switcher dropdown should be hidden. Previously it always showed regardless of the locale setting. Closes #11816.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新特性**
  * 语言切换项现在根据系统配置动态显示：当配置将语言切换禁用时，界面中不再显示该项；启用时恢复显示。
  * 帮助文档链接与版本下拉始终保留，确保文档访问与版本选择功能不受影响。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->