### PR TITLE
fix: use fixed positioning for mobile sidebar drawer

### DIFF
--- a/src/global.less
+++ b/src/global.less
@@ -65,6 +65,11 @@ body,
   display: none;
 }
 
+// Keep ProLayout's mobile inline drawer attached to the viewport while the page scrolls.
+.ant-pro-layout .ant-layout-has-sider > .ant-drawer.ant-drawer-inline {
+  position: fixed;
+}
+
 canvas {
   display: block;
 }

--- a/src/global.style.ts
+++ b/src/global.style.ts
@@ -1,17 +1,6 @@
 import { createStyles } from 'antd-style';
 
 const useStyles = createStyles(() => {
-  // Override ProLayout mobile drawer position to ensure it appears above the mask overlay.
-  // `position: fixed` is needed because ProLayout uses `ant-drawer-inline` which sets
-  // `position: absolute`, causing the drawer to render below the mask on mobile.
-  // Cast via Record to satisfy createStyles' return type for dot-separated selectors.
-  const drawerFix: Record<string, React.CSSProperties> = {
-    '.ant-drawer.ant-drawer-inline.ant-pro-drawer-sider': {
-      position:
-        'fixed !important' as unknown as React.CSSProperties['position'],
-    },
-  };
-
   return {
     colorWeak: {
       filter: 'invert(80%)',
@@ -25,7 +14,6 @@ const useStyles = createStyles(() => {
     '.ant-pro-sider-collapsed .ant-pro-sider-link span:not([role="img"])': {
       display: 'none',
     },
-    ...drawerFix,
     canvas: {
       display: 'block',
     },

--- a/src/global.style.ts
+++ b/src/global.style.ts
@@ -14,6 +14,9 @@ const useStyles = createStyles(() => {
     '.ant-pro-sider-collapsed .ant-pro-sider-link span:not([role="img"])': {
       display: 'none',
     },
+    '.ant-drawer.ant-drawer-inline.ant-pro-drawer-sider': {
+      position: 'fixed !important',
+    },
     canvas: {
       display: 'block',
     },

--- a/src/global.style.ts
+++ b/src/global.style.ts
@@ -1,6 +1,17 @@
 import { createStyles } from 'antd-style';
 
 const useStyles = createStyles(() => {
+  // Override ProLayout mobile drawer position to ensure it appears above the mask overlay.
+  // `position: fixed` is needed because ProLayout uses `ant-drawer-inline` which sets
+  // `position: absolute`, causing the drawer to render below the mask on mobile.
+  // Cast via Record to satisfy createStyles' return type for dot-separated selectors.
+  const drawerFix: Record<string, React.CSSProperties> = {
+    '.ant-drawer.ant-drawer-inline.ant-pro-drawer-sider': {
+      position:
+        'fixed !important' as unknown as React.CSSProperties['position'],
+    },
+  };
+
   return {
     colorWeak: {
       filter: 'invert(80%)',
@@ -14,9 +25,7 @@ const useStyles = createStyles(() => {
     '.ant-pro-sider-collapsed .ant-pro-sider-link span:not([role="img"])': {
       display: 'none',
     },
-    '.ant-drawer.ant-drawer-inline.ant-pro-drawer-sider': {
-      position: 'fixed !important',
-    },
+    ...drawerFix,
     canvas: {
       display: 'block',
     },


### PR DESCRIPTION
On mobile, ProLayout's inline drawer uses `position: absolute`, causing the sidebar to render below the mask overlay. Override with `position: fixed` to ensure the drawer appears above the mask. Closes #11597.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **改进**
  * 优化了移动设备上抽屉组件的滚动表现，使其在页面滚动时保持与视口固定，提升了移动端用户体验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->