### PR TITLE
fix: resolve Tailwind CSS v4 import on Windows

### DIFF
--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -1,3 +1,1 @@
-@import "tailwindcss";
-
-@source "./src";
+@import "tailwindcss/index.css";

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-  content: ['./src/**/*.tsx'],
-};


### PR DESCRIPTION
## Summary
- Use `@import "tailwindcss/index.css"` instead of `@import "tailwindcss"` for cross-platform compatibility (Windows fails to resolve the bare import)
- Remove unnecessary `@source "./src"` directive (Tailwind v4 auto-detects content)
- Delete stale `tailwind.config.js` (Tailwind v3 config no longer needed)

## Test plan
- [ ] Verify `npm start` works on Windows
- [ ] Verify Tailwind CSS classes still apply correctly
- [ ] Verify `npm run build` succeeds

Closes #11821

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores（杂务）**
  * 更新了样式构建工具配置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->