### PR TITLE
test: fix misleading test names in table-list

### DIFF
--- a/src/pages/table-list/index.test.tsx
+++ b/src/pages/table-list/index.test.tsx
@@ -145,7 +145,7 @@ describe('TableList', () => {
     expect(screen.getByText('Description')).toBeInTheDocument();
   });
 
-  it('should call removeRule mutation successfully', async () => {
+  it('should render table after data loading', async () => {
     const mockRemoveRule = vi.mocked(api.removeRule);
     mockRemoveRule.mockResolvedValue({ success: true });
 
@@ -160,7 +160,7 @@ describe('TableList', () => {
     });
   });
 
-  it('should handle empty data state', async () => {
+  it('should call rule API on mount', async () => {
     vi.mocked(api.rule).mockResolvedValue({
       data: [],
       total: 0,


### PR DESCRIPTION
## 问题

`src/pages/table-list/index.test.tsx` 中有两个测试名称与实际测试内容不符：

| 原名称 | 问题 | 新名称 |
|--------|------|--------|
| `should call removeRule mutation successfully` | 测试从未调用 removeRule，只验证了 ProTable 渲染 | `should render table after data loading` |
| `should handle empty data state` | 测试只验证 api.rule 被调用，没有断言空数据状态 UI | `should call rule API on mount` |

测试名称应准确反映其实际验证的行为，避免误导后续开发者。

Closes #11854

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* 改进了表格数据加载和API调用相关的测试用例，增强了测试覆盖范围。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->