### PR TITLE
fix: remove unused update form type

### DIFF
--- a/src/pages/table-list/components/UpdateForm.tsx
+++ b/src/pages/table-list/components/UpdateForm.tsx
@@ -12,14 +12,6 @@ import { Modal, message } from 'antd';
 import React, { cloneElement, useCallback, useState } from 'react';
 import { updateRule } from '@/services/ant-design-pro/api';
 
-type FormValueType = {
-  target?: string;
-  template?: string;
-  type?: string;
-  time?: string;
-  frequency?: string;
-} & Partial<API.RuleListItem>;
-
 type UpdateFormProps = {
   trigger?: React.ReactElement<any>;
   onOk?: () => void;


### PR DESCRIPTION
## Summary

- Remove the unused `FormValueType` alias from `UpdateForm`.

## Verification

- `npm run lint`
- `npm run test`
- `npx antd lint ./src --format json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

- **代码维护**: 清理了未使用的内部代码，优化代码库。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->