### PR TITLE
fix: resolve Tailwind CSS import on Windows

### DIFF
--- a/tailwind.css
+++ b/tailwind.css
@@ -1,3 +1,3 @@
-@import "tailwindcss";
+@import "tailwindcss/index.css";
 
 @source "./src";


### PR DESCRIPTION
## Summary
- Use the explicit Tailwind CSS entry file in `tailwind.css` so Windows resolution does not need to infer the package style export from the bare `tailwindcss` import.
- Keep the existing `@source "./src"` directive and Tailwind config unchanged to avoid changing content detection behavior.

## Test plan
- `npm run build`
- `npm run tsc`
- `npm test`
- `npx antd lint ./src --format json`

Closes #11818


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 更新了样式框架的导入配置，确保依赖项正确加载。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->