### PR TITLE
refactor: remove direct @rc-component/util dependency

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -25,3 +25,5 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: millionco/react-doctor@ced746f518f11e8283d488c4ff31c44e478bb0e5 # v2
+        with:
+          version: 0.7.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@ant-design/x": "^2.8.0",
         "@ant-design/x-markdown": "^2.8.0",
         "@ant-design/x-sdk": "^2.8.0",
-        "@rc-component/util": "^1.11.0",
         "@tanstack/react-query": "^5.101.0",
         "antd": "^6.5.0",
         "antd-style": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@ant-design/x": "^2.8.0",
     "@ant-design/x-markdown": "^2.8.0",
     "@ant-design/x-sdk": "^2.8.0",
-    "@rc-component/util": "^1.11.0",
     "@tanstack/react-query": "^5.101.0",
     "antd": "^6.5.0",
     "antd-style": "^4.1.0",

--- a/src/components/TagSelect/index.tsx
+++ b/src/components/TagSelect/index.tsx
@@ -71,7 +71,7 @@ const TagSelect: FC<TagSelectProps> & {
   const value = props.value ?? innerValue;
   const setValue = (nextValue: (string | number)[]) => {
     if (props.value === undefined) {
-      setInnerValue(nextValue);
+      setInnerValue(() => nextValue);
     }
     props.onChange?.(nextValue);
   };

--- a/src/components/TagSelect/index.tsx
+++ b/src/components/TagSelect/index.tsx
@@ -1,5 +1,4 @@
 import { DownOutlined, UpOutlined } from '@ant-design/icons';
-import { useMergedState } from '@rc-component/util';
 import { Button, Tag } from 'antd';
 import { clsx } from 'clsx';
 import React, { type FC, useMemo, useState } from 'react';
@@ -66,14 +65,16 @@ const TagSelect: FC<TagSelectProps> & {
   } = props;
   const [expand, setExpand] = useState<boolean>(false);
 
-  const [value, setValue] = useMergedState<(string | number)[]>(
+  const [innerValue, setInnerValue] = useState<(string | number)[]>(
     props.defaultValue || [],
-    {
-      value: props.value,
-      defaultValue: props.defaultValue,
-      onChange: props.onChange,
-    },
   );
+  const value = props.value ?? innerValue;
+  const setValue = (nextValue: (string | number)[]) => {
+    if (props.value === undefined) {
+      setInnerValue(nextValue);
+    }
+    props.onChange?.(nextValue);
+  };
 
   // Memoize all tags to avoid recalculating on every render
   const allTags = useMemo(() => {

--- a/src/pages/dashboard/analysis/components/Charts/ChartCard/index.tsx
+++ b/src/pages/dashboard/analysis/components/Charts/ChartCard/index.tsx
@@ -1,4 +1,3 @@
-import omit from '@rc-component/util/es/omit';
 import { Card } from 'antd';
 import type { CardProps } from 'antd/es/card';
 import { clsx } from 'clsx';
@@ -87,8 +86,13 @@ const ChartCardContent: React.FC<
 
 const ChartCard: React.FC<ChartCardProps> = (props) => {
   const { styles } = useStyles();
-  const { loading = false, ...rest } = props;
-  const cardProps = omit(rest, ['total', 'contentHeight', 'action']);
+  const {
+    loading = false,
+    total: _total,
+    contentHeight: _contentHeight,
+    action: _action,
+    ...cardProps
+  } = props;
   return (
     <Card
       loading={loading}


### PR DESCRIPTION
## Summary

- remove the direct `@rc-component/util` dependency
- replace `useMergedState` in `TagSelect` with local controlled/uncontrolled React state
- replace `omit` in `ChartCard` with object rest destructuring
- keep transitive `@rc-component/util` lockfile entries required by other packages
- pin the React Doctor Action CLI to the repository's known-good `0.7.1` version

## Why

The project only used two small utilities from `@rc-component/util`. Native React state and object destructuring cover those usages without keeping the package as a direct application dependency.

React Doctor `0.7.7` intermittently exits successfully before its Action receives a JSON report. Pinning `0.7.1` aligns CI with the repository lockfile while the upstream report-output issue is unresolved.

## Validation

- `utoo test` — 9 test files, 54 tests passed
- `utoo tsc`
- targeted Biome lint — 2 changed TSX files, no issues
- `utoo execute antd lint ./src` — 239 files scanned, no issues
- React Doctor `0.7.1` and `0.7.7` changed-file scans — 100/100, 0 diagnostics
- `utoo run build` — 89 assets built
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化标签选择组件的受控/非受控状态管理，确保选择值更新与回调触发行为一致。
  * 优化图表卡片组件的属性处理方式，保持加载状态、内容高度与操作区域展示稳定。
* **Chores**
  * 移除不再需要的内部依赖，降低安装体积与依赖冗余。
  * 更新自动化检查流程参数，固定使用指定版本。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
